### PR TITLE
Changes for v2024.11.06 release

### DIFF
--- a/charts/ndc-connector-oracle/Chart.yaml
+++ b/charts/ndc-connector-oracle/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.05
+version: v2024.11.06
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.7
+  version: 0.0.8
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-connector-oracle/Chart.yaml
+++ b/charts/ndc-connector-oracle/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.10.28
+version: v2024.11.04
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.6
+  version: 0.0.7
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-connector-oracle/Chart.yaml
+++ b/charts/ndc-connector-oracle/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.04
+version: v2024.11.05
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-connector-oracle/README.md
+++ b/charts/ndc-connector-oracle/README.md
@@ -11,6 +11,7 @@ See all [configuration](#parameters) below.
 
 # helm template and apply manifests via kubectl (example)
 helm template <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/ndc-jvm-oracle" \
   --set image.tag="my_custom_image_tag" \
   --set connectorEnvVars.JDBC_URL="jdbc_url" \
@@ -21,6 +22,7 @@ helm template <release-name> \
 
 # helm upgrade --install (pass configuration via command line)
 helm upgrade --install <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/ndc-jvm-oracle" \
   --set image.tag="my_custom_image_tag" \
   --set connectorEnvVars.JDBC_URL="jdbc_url" \

--- a/charts/ndc-connector-oracle/values.yaml
+++ b/charts/ndc-connector-oracle/values.yaml
@@ -6,8 +6,8 @@ additionalAnnotations: |
 
 # Container Configs
 image:
-  repository: "ghcr.io/hasura/ndc-connector-oracle"
-  tag: "latest"
+  repository: ""
+  tag: ""
   pullPolicy: Always
   otelCollectorRepository: otel/opentelemetry-collector-contrib
   otelCollectorTag: 0.104.0

--- a/charts/ndc-connector-phoenix/Chart.yaml
+++ b/charts/ndc-connector-phoenix/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.05
+version: v2024.11.06
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.7
+  version: 0.0.8
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-connector-phoenix/Chart.yaml
+++ b/charts/ndc-connector-phoenix/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.10.28
+version: v2024.11.04
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.6
+  version: 0.0.7
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-connector-phoenix/Chart.yaml
+++ b/charts/ndc-connector-phoenix/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.04
+version: v2024.11.05
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-connector-phoenix/README.md
+++ b/charts/ndc-connector-phoenix/README.md
@@ -11,6 +11,7 @@ See all [configuration](#parameters) below.
 
 # helm template and apply manifests via kubectl (example)
 helm template <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/ndc-jvm-phoenix" \
   --set image.tag="my_custom_image_tag" \
   --set connectorEnvVars.JDBC_URL="jdbc_url" \
@@ -21,6 +22,7 @@ helm template <release-name> \
 
 # helm upgrade --install (pass configuration via command line)
 helm upgrade --install <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/ndc-jvm-phoenix" \
   --set image.tag="my_custom_image_tag" \
   --set connectorEnvVars.JDBC_URL="jdbc_url" \

--- a/charts/ndc-connector-phoenix/values.yaml
+++ b/charts/ndc-connector-phoenix/values.yaml
@@ -6,8 +6,8 @@ additionalAnnotations: |
 
 # Container Configs
 image:
-  repository: "ghcr.io/hasura/ndc-connector-phoenix"
-  tag: "latest"
+  repository: ""
+  tag: ""
   pullPolicy: Always
   otelCollectorRepository: otel/opentelemetry-collector-contrib
   otelCollectorTag: 0.104.0

--- a/charts/ndc-elasticsearch/Chart.yaml
+++ b/charts/ndc-elasticsearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.05
+version: v2024.11.06
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.7
+  version: 0.0.8
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-elasticsearch/Chart.yaml
+++ b/charts/ndc-elasticsearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.10.28
+version: v2024.11.04
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.6
+  version: 0.0.7
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-elasticsearch/Chart.yaml
+++ b/charts/ndc-elasticsearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.04
+version: v2024.11.05
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-elasticsearch/README.md
+++ b/charts/ndc-elasticsearch/README.md
@@ -11,6 +11,7 @@ See all [configuration](#parameters) below.
 
 # helm template and apply manifests via kubectl (example)
 helm template <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/ndc-elasticsearch" \
   --set image.tag="my_custom_image_tag" \
   --set connectorEnvVars.ELASTICSEARCH_URL="elasticsearch_url" \
@@ -23,6 +24,7 @@ helm template <release-name> \
 
 # helm upgrade --install (pass configuration via command line)
 helm upgrade --install <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/ndc-elasticsearch" \
   --set image.tag="my_custom_image_tag" \
   --set connectorEnvVars.ELASTICSEARCH_URL="elasticsearch_url" \

--- a/charts/ndc-elasticsearch/values.yaml
+++ b/charts/ndc-elasticsearch/values.yaml
@@ -6,8 +6,8 @@ additionalAnnotations: |
 
 # Container Configs
 image:
-  repository: "ghcr.io/hasura/ndc-elasticsearch"
-  tag: "latest"
+  repository: ""
+  tag: ""
   pullPolicy: Always
   otelCollectorRepository: otel/opentelemetry-collector-contrib
   otelCollectorTag: 0.104.0

--- a/charts/ndc-graphql/Chart.yaml
+++ b/charts/ndc-graphql/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.05
+version: v2024.11.06
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.7
+  version: 0.0.8
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-graphql/Chart.yaml
+++ b/charts/ndc-graphql/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.10.28
+version: v2024.11.04
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.6
+  version: 0.0.7
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-graphql/Chart.yaml
+++ b/charts/ndc-graphql/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.04
+version: v2024.11.05
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-graphql/README.md
+++ b/charts/ndc-graphql/README.md
@@ -11,6 +11,7 @@ See all [configuration](#parameters) below.
 
 # helm template and apply manifests via kubectl (example)
 helm template <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/ndc-graphql" \
   --set image.tag="my_custom_image_tag" \
   --set connectorEnvVars.GRAPHQL_ENDPOINT="graphql_endpoint" \
@@ -21,6 +22,7 @@ helm template <release-name> \
 
 # helm upgrade --install (pass configuration via command line)
 helm upgrade --install <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/ndc-graphql" \
   --set image.tag="my_custom_image_tag" \
   --set connectorEnvVars.GRAPHQL_ENDPOINT="graphql_endpoint" \

--- a/charts/ndc-graphql/values.yaml
+++ b/charts/ndc-graphql/values.yaml
@@ -6,8 +6,8 @@ additionalAnnotations: |
 
 # Container Configs
 image:
-  repository: "ghcr.io/hasura/ndc-graphql"
-  tag: "latest"
+  repository: ""
+  tag: ""
   pullPolicy: Always
   otelCollectorRepository: otel/opentelemetry-collector-contrib
   otelCollectorTag: 0.104.0

--- a/charts/ndc-mongodb/Chart.yaml
+++ b/charts/ndc-mongodb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.05
+version: v2024.11.06
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.7
+  version: 0.0.8
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-mongodb/Chart.yaml
+++ b/charts/ndc-mongodb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.10.28
+version: v2024.11.04
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.6
+  version: 0.0.7
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-mongodb/Chart.yaml
+++ b/charts/ndc-mongodb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.04
+version: v2024.11.05
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-mongodb/README.md
+++ b/charts/ndc-mongodb/README.md
@@ -11,6 +11,7 @@ See all [configuration](#parameters) below.
 
 # helm template and apply manifests via kubectl (example)
 helm template <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/ndc-mongodb" \
   --set image.tag="my_custom_image_tag" \
   --set connectorEnvVars.MONGODB_DATABASE_URI="db_connection_string" \
@@ -21,6 +22,7 @@ helm template <release-name> \
 
 # helm upgrade --install (pass configuration via command line)
 helm upgrade --install <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/ndc-mongodb" \
   --set image.tag="my_custom_image_tag" \
   --set connectorEnvVars.MONGODB_DATABASE_URI="db_connection_string" \

--- a/charts/ndc-mongodb/values.yaml
+++ b/charts/ndc-mongodb/values.yaml
@@ -6,8 +6,8 @@ additionalAnnotations: |
 
 # Container Configs
 image:
-  repository: "ghcr.io/hasura/ndc-mongodb"
-  tag: "latest"
+  repository: ""
+  tag: ""
   pullPolicy: Always
   otelCollectorRepository: otel/opentelemetry-collector-contrib
   otelCollectorTag: 0.104.0

--- a/charts/ndc-nodejs-lambda/Chart.yaml
+++ b/charts/ndc-nodejs-lambda/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.05
+version: v2024.11.06
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.7
+  version: 0.0.8
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-nodejs-lambda/Chart.yaml
+++ b/charts/ndc-nodejs-lambda/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.10.28
+version: v2024.11.04
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.6
+  version: 0.0.7
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-nodejs-lambda/Chart.yaml
+++ b/charts/ndc-nodejs-lambda/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.04
+version: v2024.11.05
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-nodejs-lambda/README.md
+++ b/charts/ndc-nodejs-lambda/README.md
@@ -11,6 +11,7 @@ See all [configuration](#parameters) below.
 
 # helm template and apply manifests via kubectl (example)
 helm template <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/ndc-nodejs-lambda" \
   --set image.tag="my_custom_image_tag" \
   --set connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET="token" \
@@ -20,6 +21,7 @@ helm template <release-name> \
 
 # helm upgrade --install (pass configuration via command line)
 helm upgrade --install <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/ndc-nodejs-lambda" \
   --set image.tag="my_custom_image_tag" \
   --set connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET="token" \

--- a/charts/ndc-nodejs-lambda/values.yaml
+++ b/charts/ndc-nodejs-lambda/values.yaml
@@ -6,8 +6,8 @@ additionalAnnotations: |
 
 # Container Configs
 image:
-  repository: "ghcr.io/hasura/ndc-nodejs-lambda"
-  tag: "latest"
+  repository: ""
+  tag: ""
   pullPolicy: Always
   otelCollectorRepository: otel/opentelemetry-collector-contrib
   otelCollectorTag: 0.104.0

--- a/charts/ndc-postgres/Chart.yaml
+++ b/charts/ndc-postgres/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.05
+version: v2024.11.06
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.7
+  version: 0.0.8
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-postgres/Chart.yaml
+++ b/charts/ndc-postgres/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.10.28
+version: v2024.11.04
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.6
+  version: 0.0.7
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-postgres/Chart.yaml
+++ b/charts/ndc-postgres/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.04
+version: v2024.11.05
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-postgres/README.md
+++ b/charts/ndc-postgres/README.md
@@ -11,6 +11,7 @@ See all [configuration](#parameters) below.
 
 # helm template and apply manifests via kubectl (example)
 helm template <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/ndc-postgres" \
   --set image.tag="my_custom_image_tag" \
   --set connectorEnvVars.CONNECTION_URI="db_connection_string" \
@@ -21,6 +22,7 @@ helm template <release-name> \
 
 # helm upgrade --install (pass configuration via command line)
 helm upgrade --install <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/ndc-postgres" \
   --set image.tag="my_custom_image_tag" \
   --set connectorEnvVars.CONNECTION_URI="db_connection_string" \

--- a/charts/ndc-postgres/values.yaml
+++ b/charts/ndc-postgres/values.yaml
@@ -6,8 +6,8 @@ additionalAnnotations: |
 
 # Container Configs
 image:
-  repository: "ghcr.io/hasura/ndc-postgres"
-  tag: "latest"
+  repository: ""
+  tag: ""
   pullPolicy: Always
   otelCollectorRepository: otel/opentelemetry-collector-contrib
   otelCollectorTag: 0.104.0

--- a/charts/v3-engine/Chart.yaml
+++ b/charts/v3-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.05
+version: v2024.11.06
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.7
+  version: 0.0.8
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/v3-engine/Chart.yaml
+++ b/charts/v3-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.10.22
+version: v2024.11.04
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.6
+  version: 0.0.7
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/v3-engine/Chart.yaml
+++ b/charts/v3-engine/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2024.11.04
+version: v2024.11.05
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/v3-engine/README.md
+++ b/charts/v3-engine/README.md
@@ -11,6 +11,7 @@ See all [configuration](#parameters) below.
 
 # helm template and apply manifests via kubectl (example)
 helm template <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/v3-engine" \
   --set image.tag="my_custom_image_tag" \
   --set observability.hostName="observability_hostname" \
@@ -20,6 +21,7 @@ helm template <release-name> \
 
 # helm upgrade --install (pass configuration via command line)
 helm upgrade --install <release-name> \
+  --set namespace="default" \
   --set image.repository="my_repo/v3-engine" \
   --set image.tag="my_custom_image_tag" \
   --set observability.hostName="observability_hostname" \

--- a/charts/v3-engine/values.yaml
+++ b/charts/v3-engine/values.yaml
@@ -6,8 +6,8 @@ additionalAnnotations: |
 
 image:
   # Full path to custom created image
-  repository: ghcr.io/hasura/v3-engine
-  tag: "latest"
+  repository: ""
+  tag: ""
   pullPolicy: Always
   otelCollectorRepository: otel/opentelemetry-collector-contrib
   otelCollectorTag: 0.104.0


### PR DESCRIPTION
Following changes for releasing v2024.11.06 to all Helm charts

- Bump common to 0.0.8 (Contains additional validation on `image.repository`)
- Set `image.repository` and `image.tag` to empty string
- Add setting namespace to examples under all README files