### PR TITLE
Add QUARKUS ENVs to ndc-connector-oracle

### DIFF
--- a/charts/ndc-connector-oracle/Chart.yaml
+++ b/charts/ndc-connector-oracle/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.01.14
+version: v2025.03.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-connector-oracle/README.md
+++ b/charts/ndc-connector-oracle/README.md
@@ -54,6 +54,9 @@ helm upgrade --install <release-name> \
 | `connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET`    | Hasura Service Token Secret (Optional)                                                                     | `""`                                 |
 | `connectorEnvVars.JDBC_URL`                       | The JDBC URL to connect to the database (Required)                                                                         | `""`                                 |
 | `connectorEnvVars.JDBC_SCHEMAS`                   | A comma-separated list of schemas to include in the metadata (Optional)                                                                         | `""`                                 |
+| `connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`                   | Sets the OTLP endpoint to send telemetry data (traces) (Optional)                                                                         | `""`                                 |
+| `connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`                   | Sets the OTLP endpoint to send telemetry data (metrics)(Optional)                                                                         | `""`                                 |
+| `connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING`                   | Enable or disable tracing for JDBC connections (Optional)                                                                         | `false`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) | `"/etc/connector"`                   |
 
 ## Additional Parameters

--- a/charts/ndc-connector-oracle/values.yaml
+++ b/charts/ndc-connector-oracle/values.yaml
@@ -148,6 +148,9 @@ connectorEnvVars:
   HASURA_SERVICE_TOKEN_SECRET: ""
   JDBC_URL: ""
   JDBC_SCHEMAS: ""
+  QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ""
+  QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: ""
+  QUARKUS_DATASOURCE_JDBC_TRACING: ""
   configDirectory: /etc/connector
 
 env: |
@@ -166,6 +169,18 @@ env: |
   {{- if .Values.connectorEnvVars.JDBC_SCHEMAS }}
   - name: JDBC_SCHEMAS
     value: {{ .Values.connectorEnvVars.JDBC_SCHEMAS | quote }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}
+  - name: QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    value: {{ .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT }}
+  - name: QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+    value: {{ .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING }}
+  - name: QUARKUS_DATASOURCE_JDBC_TRACING
+    value: {{ .Values.connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING }}
   {{- end }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: http://localhost:4317


### PR DESCRIPTION
Add following ENVs to `ndc-connector-oracle`:

- `QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
- `QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
- `QUARKUS_DATASOURCE_JDBC_TRACING`

For reference: https://quarkus.io/guides/opentelemetry#configuration-reference