### PR TITLE
Observability for all connectors

### DIFF
--- a/charts/ndc-bigquery/Chart.yaml
+++ b/charts/ndc-bigquery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.04.03
+version: v2025.04.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-bigquery/README.md
+++ b/charts/ndc-bigquery/README.md
@@ -71,6 +71,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.HASURA_BIGQUERY_PROJECT_ID`     | The BigQuery project ID/name (Required)                                                                    | `""`                            |
 | `connectorEnvVars.HASURA_BIGQUERY_DATASET_ID`     | The BigQuery dataset ID/name (Required)                                                                    | `""`                            |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
 
 ## Additional Parameters
 
@@ -80,15 +81,6 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `image.repository`                                | Image repository containing custom created ndc-bigquery                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-bigquery                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |
-| `image.otelCollectorRepository`                   | OTEL collector image repository                                                                            | `otel/opentelemetry-collector`  |
-| `image.otelCollectorTag`                          | OTEL collector image tag                                                                                   | `0.104.0`                       |
-| `observability.enabled`                           | Deploy OTEL collector as sidecar                                                                           | `true`                          |
-| `dataPlane.id`                                    | Data Plane ID (Required when observability.enabled is set to true)                                         | `""`                         |
-| `dataPlane.key`                                   | Data Plane Key (Required when observability.enabled is set to true)                                        | `""`                         |
-| `controlPlane.otlpEndpoint`                       | OTEL endpoint under Hasura                                                                                 | `"https://gateway.otlp.hasura.io:443"`                         |
-| `controlPlane.oauthTokenEndpoint`                 | Oauth Token URL                                                                                            | `"https://ddn-oauth.pro.hasura.io/oauth2/token"`                         |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the ndc-bigquery pod                               | `[]`                            |
-| `extraContainers`                                 | Optionally specify extra list of additional containers for the ndc-bigquery pod                            | `[]`                               |                               |
 | `resources`                                       | Resource requests and limits of ndc-bigquery container                                                     | `{}`                            |
 | `env`                                             | Env variable section for ndc-bigquery                                                                      | `[]`                            |
 | `replicas`                                        | Replicas setting for pod                                                                                   | `1`                             |

--- a/charts/ndc-bigquery/README.md
+++ b/charts/ndc-bigquery/README.md
@@ -71,7 +71,8 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.HASURA_BIGQUERY_PROJECT_ID`     | The BigQuery project ID/name (Required)                                                                    | `""`                            |
 | `connectorEnvVars.HASURA_BIGQUERY_DATASET_ID`     | The BigQuery dataset ID/name (Required)                                                                    | `""`                            |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
-| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"` |
+| `connectorEnvVars.OTEL_SERVICE_NAME`              | OTEL Service Name (Optional)                                                                               | `ndc-bigquery`                  |
 
 ## Additional Parameters
 

--- a/charts/ndc-bigquery/templates/secret.yaml
+++ b/charts/ndc-bigquery/templates/secret.yaml
@@ -10,6 +10,3 @@ data:
   HASURA_BIGQUERY_SERVICE_KEY: {{ required "Error: .Values.connectorEnvVars.HASURA_BIGQUERY_SERVICE_KEY is required!" .Values.connectorEnvVars.HASURA_BIGQUERY_SERVICE_KEY | b64enc | quote }}
   HASURA_BIGQUERY_PROJECT_ID: {{ required "Error: .Values.connectorEnvVars.HASURA_BIGQUERY_PROJECT_ID is required!" .Values.connectorEnvVars.HASURA_BIGQUERY_PROJECT_ID | b64enc | quote }}
   HASURA_BIGQUERY_DATASET_ID: {{ required "Error: .Values.connectorEnvVars.HASURA_BIGQUERY_DATASET_ID is required!" .Values.connectorEnvVars.HASURA_BIGQUERY_DATASET_ID | b64enc | quote }}
-  {{- if .Values.observability.enabled }}
-  otel-collector-config.yaml: {{ (tpl .Values.otel.config .) | b64enc | quote }}
-  {{- end }}

--- a/charts/ndc-bigquery/values.yaml
+++ b/charts/ndc-bigquery/values.yaml
@@ -60,6 +60,7 @@ connectorEnvVars:
   HASURA_BIGQUERY_DATASET_ID: ""
   configDirectory: ""
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  OTEL_SERVICE_NAME: ""
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -86,6 +87,13 @@ env: |
         name: {{ printf "%s-secret" (include "common.name" .) }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-bigquery/values.yaml
+++ b/charts/ndc-bigquery/values.yaml
@@ -8,8 +8,6 @@ image:
   repository: ""
   tag: ""
   pullPolicy: Always
-  otelCollectorRepository: otel/opentelemetry-collector-contrib
-  otelCollectorTag: 0.104.0
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:
@@ -47,94 +45,6 @@ hpa:
           type: Utilization
           averageUtilization: 80  # Target 80% memory utilization per pod
 
-# Observability defaults are tuned for Hasura hosted Control Plane
-observability:
-  enabled: false
-
-# Required (when observability.enabled is set to true)
-dataPlane:
-  id: ""
-  key: ""
-
-controlPlane:
-  otlpEndpoint: https://gateway.otlp.hasura.io:443
-  oauthTokenEndpoint: https://ddn-oauth.pro.hasura.io/oauth2/token
-
-otel:
-  config: |
-    extensions:
-      oauth2client:
-        client_id: {{ required "Error: .Values.dataPlane.id is required!" .Values.dataPlane.id }}
-        client_secret: {{ required "Error: .Values.dataPlane.key is required!" .Values.dataPlane.key }}
-        token_url: {{ .Values.controlPlane.oauthTokenEndpoint }}
-        scopes: ["opentelemetry:write"]
-        endpoint_params:
-          audience: https://ddn.hasura.io
-    exporters:
-      otlp/oauth:
-        endpoint: {{ .Values.controlPlane.otlpEndpoint }}
-        auth:
-          authenticator: oauth2client
-    processors:
-      batch: {}
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    service:
-      extensions: [oauth2client]
-      pipelines:
-        logs:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        metrics:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        traces:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-
-extraVolumes: |
-  {{- if .Values.observability.enabled }}
-  - name: otel-config
-    secret:
-      secretName: {{ printf "%s-secret" (include "common.name" .) }}
-      items:
-        - key: otel-collector-config.yaml
-          path: otel-collector-config.yaml
-  {{- end }}
-
-extraContainers: |
-  {{- if .Values.observability.enabled }}
-  - name: "otel-collector"
-    command:
-      - --config=/etc/otel-collector-config.yaml
-    command:
-    image: {{ template "common.image" (dict "Values" $.Values "repository" .Values.image.otelCollectorRepository "tag" .Values.image.otelCollectorTag) }}
-    env:
-    - name: "OTEL_ENDPOINT"
-      value: "{{ .Values.controlPlane.otlpEndpoint }}"
-    volumeMounts:
-      - name: otel-config
-        mountPath: "/etc/otelcol-contrib/config.yaml"
-        subPath: otel-collector-config.yaml
-  {{- end }}
-
 resources: |
   requests:
     cpu: "500m"
@@ -149,6 +59,7 @@ connectorEnvVars:
   HASURA_BIGQUERY_PROJECT_ID: ""
   HASURA_BIGQUERY_DATASET_ID: ""
   configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -174,7 +85,7 @@ env: |
         key: HASURA_BIGQUERY_DATASET_ID
         name: {{ printf "%s-secret" (include "common.name" .) }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: http://localhost:4317
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-connector-oracle/Chart.yaml
+++ b/charts/ndc-connector-oracle/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.04.03
+version: v2025.04.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-connector-oracle/README.md
+++ b/charts/ndc-connector-oracle/README.md
@@ -67,6 +67,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`                   | Sets the OTLP endpoint to send telemetry data (metrics)(Optional)                                                                         | `""`                                 |
 | `connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING`                   | Enable or disable tracing for JDBC connections (Optional)                                                                         | `false`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
 
 ## Additional Parameters
 
@@ -76,15 +77,6 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `image.repository`                                | Image repository containing custom created ndc-connector-oracle                                                     | `""`                                |
 | `image.tag`                                       | Image tag to use for custom created ndc-connector-oracle                                                            | `""`                                |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                            |
-| `image.otelCollectorRepository`                   | OTEL collector image repository                                                                            | `otel/opentelemetry-collector`      |
-| `image.otelCollectorTag`                          | OTEL collector image tag                                                                                   | `0.104.0`                           |
-| `observability.enabled`                           | Deploy OTEL collector as sidecar                                                                           | `false`                          |
-| `dataPlane.id`                                    | Data Plane ID (Required when observability.enabled is set to true)                                         | `""`                         |
-| `dataPlane.key`                                   | Data Plane Key (Required when observability.enabled is set to true)                                        | `""`                         |
-| `controlPlane.otlpEndpoint`                       | OTEL endpoint under Hasura                                                                                 | `"https://gateway.otlp.hasura.io:443"`                         |
-| `controlPlane.oauthTokenEndpoint`                 | Oauth Token URL                                                                                            | `"https://ddn-oauth.pro.hasura.io/oauth2/token"`                         |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the ndc-connector-oracle pod                                | `[]`                                |
-| `extraContainers`                                 | Optionally specify extra list of additional containers for the ndc-connector-oracle pod                             | `[]`                                |
 | `resources`                                       | Resource requests and limits of ndc-connector-oracle container                                                      | `{}`                                |
 | `env`                                             | Env variable section for ndc-connector-oracle                                                                       | `[]`                                |
 | `replicas`                                        | Replicas setting for pod                                                                                   | `1`                                 |

--- a/charts/ndc-connector-oracle/README.md
+++ b/charts/ndc-connector-oracle/README.md
@@ -63,11 +63,11 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET`    | Hasura Service Token Secret (Optional)                                                                     | `""`                                 |
 | `connectorEnvVars.JDBC_URL`                       | The JDBC URL to connect to the database (Required)                                                                         | `""`                                 |
 | `connectorEnvVars.JDBC_SCHEMAS`                   | A comma-separated list of schemas to include in the metadata (Optional)                                                                         | `""`                                 |
-| `connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`                   | Sets the OTLP endpoint to send telemetry data (traces) (Optional)                                                                         | `""`                                 |
-| `connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`                   | Sets the OTLP endpoint to send telemetry data (metrics)(Optional)                                                                         | `""`                                 |
-| `connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING`                   | Enable or disable tracing for JDBC connections (Optional)                                                                         | `false`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
-| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`                   | Sets the OTLP endpoint to send telemetry data (traces) (Optional)                                                                         | `"http://dp-otel-collector:4317"`                                 |
+| `connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`                   | Sets the OTLP endpoint to send telemetry data (metrics)(Optional)                                                                         | `"http://dp-otel-collector:4317"`                                 |
+| `connectorEnvVars.QUARKUS_OTEL_SERVICE_NAME`           | Sets OTEL Service Name (Optional)                                                                         | `"ndc-connector-oracle"`                                 |
+| `connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING`                   | Enable or disable tracing for JDBC connections (Optional)                                                                         | `true`                                 |
 
 ## Additional Parameters
 

--- a/charts/ndc-connector-oracle/templates/secret.yaml
+++ b/charts/ndc-connector-oracle/templates/secret.yaml
@@ -8,6 +8,3 @@ data:
   HASURA_SERVICE_TOKEN_SECRET: {{ required "Error: .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET is required!" .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET | b64enc | quote }}
   {{- end }}
   JDBC_URL: {{ required "Error: .Values.connectorEnvVars.JDBC_URL is required!" .Values.connectorEnvVars.JDBC_URL | b64enc | quote }}
-{{- if .Values.observability.enabled }}
-  otel-collector-config.yaml: {{ (tpl .Values.otel.config .) | b64enc | quote }}
-{{- end }}

--- a/charts/ndc-connector-oracle/values.yaml
+++ b/charts/ndc-connector-oracle/values.yaml
@@ -8,8 +8,6 @@ image:
   repository: ""
   tag: ""
   pullPolicy: Always
-  otelCollectorRepository: otel/opentelemetry-collector-contrib
-  otelCollectorTag: 0.104.0
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:
@@ -47,94 +45,6 @@ hpa:
           type: Utilization
           averageUtilization: 80  # Target 80% memory utilization per pod
 
-# Observability defaults are tuned for Hasura hosted Control Plane
-observability:
-  enabled: false
-
-# Required (when observability.enabled is set to true)
-dataPlane:
-  id: ""
-  key: ""
-
-controlPlane:
-  otlpEndpoint: https://gateway.otlp.hasura.io:443
-  oauthTokenEndpoint: https://ddn-oauth.pro.hasura.io/oauth2/token
-
-otel:
-  config: |
-    extensions:
-      oauth2client:
-        client_id: {{ required "Error: .Values.dataPlane.id is required!" .Values.dataPlane.id }}
-        client_secret: {{ required "Error: .Values.dataPlane.key is required!" .Values.dataPlane.key }}
-        token_url: {{ .Values.controlPlane.oauthTokenEndpoint }}
-        scopes: ["opentelemetry:write"]
-        endpoint_params:
-          audience: https://ddn.hasura.io
-    exporters:
-      otlp/oauth:
-        endpoint: {{ .Values.controlPlane.otlpEndpoint }}
-        auth:
-          authenticator: oauth2client
-    processors:
-      batch: {}
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    service:
-      extensions: [oauth2client]
-      pipelines:
-        logs:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        metrics:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        traces:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-
-extraVolumes: |
-  {{- if .Values.observability.enabled }}
-  - name: otel-config
-    secret:
-      secretName: {{ printf "%s-secret" (include "common.name" .) }}
-      items:
-        - key: otel-collector-config.yaml
-          path: otel-collector-config.yaml
-  {{- end }}
-
-extraContainers: |
-  {{- if .Values.observability.enabled }}
-  - name: "otel-collector"
-    command:
-      - --config=/etc/otel-collector-config.yaml
-    command:
-    image: {{ template "common.image" (dict "Values" $.Values "repository" .Values.image.otelCollectorRepository "tag" .Values.image.otelCollectorTag) }}
-    env:
-    - name: "OTEL_ENDPOINT"
-      value: "{{ .Values.controlPlane.otlpEndpoint }}"
-    volumeMounts:
-      - name: otel-config
-        mountPath: "/etc/otelcol-contrib/config.yaml"
-        subPath: otel-collector-config.yaml
-  {{- end }}
-
 resources: |
   requests:
     cpu: "500m"
@@ -151,6 +61,7 @@ connectorEnvVars:
   QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: ""
   QUARKUS_DATASOURCE_JDBC_TRACING: ""
   configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -182,7 +93,7 @@ env: |
     value: {{ .Values.connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING | quote }}
   {{- end }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: http://localhost:4317
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-connector-oracle/values.yaml
+++ b/charts/ndc-connector-oracle/values.yaml
@@ -57,11 +57,11 @@ connectorEnvVars:
   HASURA_SERVICE_TOKEN_SECRET: ""
   JDBC_URL: ""
   JDBC_SCHEMAS: ""
-  QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: ""
-  QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: ""
-  QUARKUS_DATASOURCE_JDBC_TRACING: ""
   configDirectory: ""
-  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://dp-otel-collector:4317"
+  QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "http://dp-otel-collector:4317"
+  QUARKUS_OTEL_SERVICE_NAME: ""
+  QUARKUS_DATASOURCE_JDBC_TRACING: true
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -88,12 +88,17 @@ env: |
   - name: QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
     value: {{ .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT }}
   {{- end }}
+  {{- if .Values.connectorEnvVars.QUARKUS_OTEL_SERVICE_NAME }}
+  - name: QUARKUS_OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.QUARKUS_OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: QUARKUS_OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
   {{- if .Values.connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING }}
   - name: QUARKUS_DATASOURCE_JDBC_TRACING
     value: {{ .Values.connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING | quote }}
   {{- end }}
-  - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-connector-phoenix/Chart.yaml
+++ b/charts/ndc-connector-phoenix/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.04.03
+version: v2025.04.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-connector-phoenix/README.md
+++ b/charts/ndc-connector-phoenix/README.md
@@ -63,7 +63,10 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET`    | Hasura Service Token Secret (Optional)                                                                     | `""`                                 |
 | `connectorEnvVars.JDBC_URL`                       | The JDBC URL to connect to the database (Required)                                                                         | `""`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
-| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`                   | Sets the OTLP endpoint to send telemetry data (traces) (Optional)                                                                         | `"http://dp-otel-collector:4317"`                                 |
+| `connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`                   | Sets the OTLP endpoint to send telemetry data (metrics)(Optional)                                                                         | `"http://dp-otel-collector:4317"`                                 |
+| `connectorEnvVars.QUARKUS_OTEL_SERVICE_NAME`           | Sets OTEL Service Name (Optional)                                                                         | `"ndc-connector-oracle"`                                 |
+| `connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING`                   | Enable or disable tracing for JDBC connections (Optional)                                                                         | `true`                                 |
 
 ## Additional Parameters
 

--- a/charts/ndc-connector-phoenix/README.md
+++ b/charts/ndc-connector-phoenix/README.md
@@ -63,6 +63,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET`    | Hasura Service Token Secret (Optional)                                                                     | `""`                                 |
 | `connectorEnvVars.JDBC_URL`                       | The JDBC URL to connect to the database (Required)                                                                         | `""`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
 
 ## Additional Parameters
 
@@ -72,15 +73,6 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `image.repository`                                | Image repository containing custom created ndc-connector-phoenix                                                    | `""`                                |
 | `image.tag`                                       | Image tag to use for custom created ndc-connector-phoenix                                                           | `""`                                |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                            |
-| `image.otelCollectorRepository`                   | OTEL collector image repository                                                                            | `otel/opentelemetry-collector`      |
-| `image.otelCollectorTag`                          | OTEL collector image tag                                                                                   | `0.104.0`                           |
-| `observability.enabled`                           | Deploy OTEL collector as sidecar                                                                           | `true`                          |
-| `dataPlane.id`                                    | Data Plane ID (Required when observability.enabled is set to true)                                         | `""`                         |
-| `dataPlane.key`                                   | Data Plane Key (Required when observability.enabled is set to true)                                        | `""`                         |
-| `controlPlane.otlpEndpoint`                       | OTEL endpoint under Hasura                                                                                 | `"https://gateway.otlp.hasura.io:443"`                         |
-| `controlPlane.oauthTokenEndpoint`                 | Oauth Token URL                                                                                            | `"https://ddn-oauth.pro.hasura.io/oauth2/token"`                         |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the ndc-connector-phoenix pod                                | `[]`                                |
-| `extraContainers`                                 | Optionally specify extra list of additional containers for the ndc-connector-phoenix pod                             | `[]`                                |
 | `resources`                                       | Resource requests and limits of ndc-connector-phoenix container                                                      | `{}`                                |
 | `env`                                             | Env variable section for ndc-connector-phoenix                                                                      | `[]`                                |
 | `replicas`                                        | Replicas setting for pod                                                                                   | `1`                                 |

--- a/charts/ndc-connector-phoenix/README.md
+++ b/charts/ndc-connector-phoenix/README.md
@@ -65,7 +65,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
 | `connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`                   | Sets the OTLP endpoint to send telemetry data (traces) (Optional)                                                                         | `"http://dp-otel-collector:4317"`                                 |
 | `connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`                   | Sets the OTLP endpoint to send telemetry data (metrics)(Optional)                                                                         | `"http://dp-otel-collector:4317"`                                 |
-| `connectorEnvVars.QUARKUS_OTEL_SERVICE_NAME`           | Sets OTEL Service Name (Optional)                                                                         | `"ndc-connector-oracle"`                                 |
+| `connectorEnvVars.QUARKUS_OTEL_SERVICE_NAME`           | Sets OTEL Service Name (Optional)                                                                         | `"ndc-connector-phoenix"`                                 |
 | `connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING`                   | Enable or disable tracing for JDBC connections (Optional)                                                                         | `true`                                 |
 
 ## Additional Parameters

--- a/charts/ndc-connector-phoenix/templates/secret.yaml
+++ b/charts/ndc-connector-phoenix/templates/secret.yaml
@@ -8,6 +8,3 @@ data:
   HASURA_SERVICE_TOKEN_SECRET: {{ required "Error: .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET is required!" .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET | b64enc | quote }}
   {{- end }}
   JDBC_URL: {{ required "Error: .Values.connectorEnvVars.JDBC_URL is required!" .Values.connectorEnvVars.JDBC_URL | b64enc | quote }}
-{{- if .Values.observability.enabled }}
-  otel-collector-config.yaml: {{ (tpl .Values.otel.config .) | b64enc | quote }}
-{{- end }}

--- a/charts/ndc-connector-phoenix/values.yaml
+++ b/charts/ndc-connector-phoenix/values.yaml
@@ -57,7 +57,10 @@ connectorEnvVars:
   HASURA_SERVICE_TOKEN_SECRET: ""
   JDBC_URL: ""
   configDirectory: ""
-  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://dp-otel-collector:4317"
+  QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "http://dp-otel-collector:4317"
+  QUARKUS_OTEL_SERVICE_NAME: ""
+  QUARKUS_DATASOURCE_JDBC_TRACING: true
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -72,8 +75,25 @@ env: |
       secretKeyRef:
         key: JDBC_URL
         name: {{ printf "%s-secret" (include "common.name" .) }}
-  - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}
+  - name: QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    value: {{ .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT }}
+  - name: QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+    value: {{ .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.QUARKUS_OTEL_SERVICE_NAME }}
+  - name: QUARKUS_OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.QUARKUS_OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: QUARKUS_OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING }}
+  - name: QUARKUS_DATASOURCE_JDBC_TRACING
+    value: {{ .Values.connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING | quote }}
+  {{- end }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-connector-phoenix/values.yaml
+++ b/charts/ndc-connector-phoenix/values.yaml
@@ -8,8 +8,6 @@ image:
   repository: ""
   tag: ""
   pullPolicy: Always
-  otelCollectorRepository: otel/opentelemetry-collector-contrib
-  otelCollectorTag: 0.104.0
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:
@@ -47,94 +45,6 @@ hpa:
           type: Utilization
           averageUtilization: 80  # Target 80% memory utilization per pod
 
-# Observability defaults are tuned for Hasura hosted Control Plane
-observability:
-  enabled: false
-
-# Required (when observability.enabled is set to true)
-dataPlane:
-  id: ""
-  key: ""
-
-controlPlane:
-  otlpEndpoint: https://gateway.otlp.hasura.io:443
-  oauthTokenEndpoint: https://ddn-oauth.pro.hasura.io/oauth2/token
-
-otel:
-  config: |
-    extensions:
-      oauth2client:
-        client_id: {{ required "Error: .Values.dataPlane.id is required!" .Values.dataPlane.id }}
-        client_secret: {{ required "Error: .Values.dataPlane.key is required!" .Values.dataPlane.key }}
-        token_url: {{ .Values.controlPlane.oauthTokenEndpoint }}
-        scopes: ["opentelemetry:write"]
-        endpoint_params:
-          audience: https://ddn.hasura.io
-    exporters:
-      otlp/oauth:
-        endpoint: {{ .Values.controlPlane.otlpEndpoint }}
-        auth:
-          authenticator: oauth2client
-    processors:
-      batch: {}
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    service:
-      extensions: [oauth2client]
-      pipelines:
-        logs:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        metrics:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        traces:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-
-extraVolumes: |
-  {{- if .Values.observability.enabled }}
-  - name: otel-config
-    secret:
-      secretName: {{ printf "%s-secret" (include "common.name" .) }}
-      items:
-        - key: otel-collector-config.yaml
-          path: otel-collector-config.yaml
-  {{- end }}
-
-extraContainers: |
-  {{- if .Values.observability.enabled }}
-  - name: "otel-collector"
-    command:
-      - --config=/etc/otel-collector-config.yaml
-    command:
-    image: {{ template "common.image" (dict "Values" $.Values "repository" .Values.image.otelCollectorRepository "tag" .Values.image.otelCollectorTag) }}
-    env:
-    - name: "OTEL_ENDPOINT"
-      value: "{{ .Values.controlPlane.otlpEndpoint }}"
-    volumeMounts:
-      - name: otel-config
-        mountPath: "/etc/otelcol-contrib/config.yaml"
-        subPath: otel-collector-config.yaml
-  {{- end }}
-
 resources: |
   requests:
     cpu: "500m"
@@ -147,6 +57,7 @@ connectorEnvVars:
   HASURA_SERVICE_TOKEN_SECRET: ""
   JDBC_URL: ""
   configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -162,7 +73,7 @@ env: |
         key: JDBC_URL
         name: {{ printf "%s-secret" (include "common.name" .) }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: http://localhost:4317
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-elasticsearch/Chart.yaml
+++ b/charts/ndc-elasticsearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.04.03
+version: v2025.04.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-elasticsearch/README.md
+++ b/charts/ndc-elasticsearch/README.md
@@ -76,6 +76,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.ELASTICSEARCH_DEFAULT_RESULT_SIZE`               | The default query size when no limit is applied. Defaults to 10,000 (Optional)                                                                            | `""`                            |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
 | `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.OTEL_SERVICE_NAME`              | OTEL Service Name (Optional)                                                                               | `ndc-elasticsearch`                  |
 
 ## Additional Parameters
 

--- a/charts/ndc-elasticsearch/README.md
+++ b/charts/ndc-elasticsearch/README.md
@@ -75,6 +75,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.ELASTICSEARCH_INDEX_PATTERN`               | The pattern for matching Elasticsearch indices, potentially including wildcards, used by the connector (Optional)                                                                            | `""`                            |
 | `connectorEnvVars.ELASTICSEARCH_DEFAULT_RESULT_SIZE`               | The default query size when no limit is applied. Defaults to 10,000 (Optional)                                                                            | `""`                            |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
 
 ## Additional Parameters
 
@@ -84,15 +85,6 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `image.repository`                                | Image repository containing custom created ndc-elasticsearch                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-elasticsearch                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |
-| `image.otelCollectorRepository`                   | OTEL collector image repository                                                                            | `otel/opentelemetry-collector`  |
-| `image.otelCollectorTag`                          | OTEL collector image tag                                                                                   | `0.104.0`                       |
-| `observability.enabled`                           | Deploy OTEL collector as sidecar                                                                           | `true`                          |
-| `dataPlane.id`                                    | Data Plane ID (Required when observability.enabled is set to true)                                         | `""`                         |
-| `dataPlane.key`                                   | Data Plane Key (Required when observability.enabled is set to true)                                        | `""`                         |
-| `controlPlane.otlpEndpoint`                       | OTEL endpoint under Hasura                                                                                 | `"https://gateway.otlp.hasura.io:443"`                         |
-| `controlPlane.oauthTokenEndpoint`                 | Oauth Token URL                                                                                            | `"https://ddn-oauth.pro.hasura.io/oauth2/token"`                         |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the ndc-elasticsearch pod                               | `[]`                            |
-| `extraContainers`                                 | Optionally specify extra list of additional containers for the ndc-elasticsearch pod                            | `[]`                               |                               |
 | `resources`                                       | Resource requests and limits of ndc-elasticsearch container                                                     | `{}`                            |
 | `env`                                             | Env variable section for ndc-elasticsearch                                                                      | `[]`                            |
 | `replicas`                                        | Replicas setting for pod                                                                                   | `1`                             |

--- a/charts/ndc-elasticsearch/templates/secret.yaml
+++ b/charts/ndc-elasticsearch/templates/secret.yaml
@@ -22,6 +22,3 @@ data:
   {{- if .Values.connectorEnvVars.ELASTICSEARCH_DEFAULT_RESULT_SIZE }}
   ELASTICSEARCH_DEFAULT_RESULT_SIZE: {{ .Values.connectorEnvVars.ELASTICSEARCH_DEFAULT_RESULT_SIZE | b64enc | quote }}
   {{- end }}
-{{- if .Values.observability.enabled }}
-  otel-collector-config.yaml: {{ (tpl .Values.otel.config .) | b64enc | quote }}
-{{- end }}

--- a/charts/ndc-elasticsearch/values.yaml
+++ b/charts/ndc-elasticsearch/values.yaml
@@ -8,8 +8,6 @@ image:
   repository: ""
   tag: ""
   pullPolicy: Always
-  otelCollectorRepository: otel/opentelemetry-collector-contrib
-  otelCollectorTag: 0.104.0
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:
@@ -47,94 +45,6 @@ hpa:
           type: Utilization
           averageUtilization: 80  # Target 80% memory utilization per pod
 
-# Observability defaults are tuned for Hasura hosted Control Plane
-observability:
-  enabled: false
-
-# Required (when observability.enabled is set to true)
-dataPlane:
-  id: ""
-  key: ""
-
-controlPlane:
-  otlpEndpoint: https://gateway.otlp.hasura.io:443
-  oauthTokenEndpoint: https://ddn-oauth.pro.hasura.io/oauth2/token
-
-otel:
-  config: |
-    extensions:
-      oauth2client:
-        client_id: {{ required "Error: .Values.dataPlane.id is required!" .Values.dataPlane.id }}
-        client_secret: {{ required "Error: .Values.dataPlane.key is required!" .Values.dataPlane.key }}
-        token_url: {{ .Values.controlPlane.oauthTokenEndpoint }}
-        scopes: ["opentelemetry:write"]
-        endpoint_params:
-          audience: https://ddn.hasura.io
-    exporters:
-      otlp/oauth:
-        endpoint: {{ .Values.controlPlane.otlpEndpoint }}
-        auth:
-          authenticator: oauth2client
-    processors:
-      batch: {}
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    service:
-      extensions: [oauth2client]
-      pipelines:
-        logs:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        metrics:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        traces:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-
-extraVolumes: |
-  {{- if .Values.observability.enabled }}
-  - name: otel-config
-    secret:
-      secretName: {{ printf "%s-secret" (include "common.name" .) }}
-      items:
-        - key: otel-collector-config.yaml
-          path: otel-collector-config.yaml
-  {{- end }}
-
-extraContainers: |
-  {{- if .Values.observability.enabled }}
-  - name: "otel-collector"
-    command:
-      - --config=/etc/otel-collector-config.yaml
-    command:
-    image: {{ template "common.image" (dict "Values" $.Values "repository" .Values.image.otelCollectorRepository "tag" .Values.image.otelCollectorTag) }}
-    env:
-    - name: "OTEL_ENDPOINT"
-      value: "{{ .Values.controlPlane.otlpEndpoint }}"
-    volumeMounts:
-      - name: otel-config
-        mountPath: "/etc/otelcol-contrib/config.yaml"
-        subPath: otel-collector-config.yaml
-  {{- end }}
-
 resources: |
   requests:
     cpu: "500m"
@@ -153,6 +63,7 @@ connectorEnvVars:
   ELASTICSEARCH_INDEX_PATTERN: ""
   ELASTICSEARCH_DEFAULT_RESULT_SIZE: ""
   configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -206,7 +117,7 @@ env: |
         name: {{ printf "%s-secret" (include "common.name" .) }}
   {{- end }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: http://localhost:4317
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-elasticsearch/values.yaml
+++ b/charts/ndc-elasticsearch/values.yaml
@@ -64,6 +64,7 @@ connectorEnvVars:
   ELASTICSEARCH_DEFAULT_RESULT_SIZE: ""
   configDirectory: ""
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  OTEL_SERVICE_NAME: ""
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -118,6 +119,13 @@ env: |
   {{- end }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-graphql/Chart.yaml
+++ b/charts/ndc-graphql/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.04.03
+version: v2025.04.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-graphql/README.md
+++ b/charts/ndc-graphql/README.md
@@ -64,6 +64,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.GRAPHQL_ENDPOINT`               | The GraphQL Endpoint (Required)                                                                            | `""`                            |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
 | `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.OTEL_SERVICE_NAME`              | OTEL Service Name (Optional)                                                                               | `ndc-graphql`                  |
 
 ## Additional Parameters
 

--- a/charts/ndc-graphql/README.md
+++ b/charts/ndc-graphql/README.md
@@ -63,6 +63,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET`    | Hasura Service Token Secret (Optional)                                                                     | `""`                            |
 | `connectorEnvVars.GRAPHQL_ENDPOINT`               | The GraphQL Endpoint (Required)                                                                            | `""`                            |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
 
 ## Additional Parameters
 
@@ -72,15 +73,6 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `image.repository`                                | Image repository containing custom created ndc-graphql                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-graphql                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |
-| `image.otelCollectorRepository`                   | OTEL collector image repository                                                                            | `otel/opentelemetry-collector`  |
-| `image.otelCollectorTag`                          | OTEL collector image tag                                                                                   | `0.104.0`                       |
-| `observability.enabled`                           | Deploy OTEL collector as sidecar                                                                           | `true`                          |
-| `dataPlane.id`                                    | Data Plane ID (Required when observability.enabled is set to true)                                         | `""`                         |
-| `dataPlane.key`                                   | Data Plane Key (Required when observability.enabled is set to true)                                        | `""`                         |
-| `controlPlane.otlpEndpoint`                       | OTEL endpoint under Hasura                                                                                 | `"https://gateway.otlp.hasura.io:443"`                         |
-| `controlPlane.oauthTokenEndpoint`                 | Oauth Token URL                                                                                            | `"https://ddn-oauth.pro.hasura.io/oauth2/token"`                         |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the ndc-graphql pod                               | `[]`                            |
-| `extraContainers`                                 | Optionally specify extra list of additional containers for the ndc-graphql pod                            | `[]`                               |                               |
 | `resources`                                       | Resource requests and limits of ndc-graphql container                                                     | `{}`                            |
 | `env`                                             | Env variable section for ndc-graphql                                                                      | `[]`                            |
 | `replicas`                                        | Replicas setting for pod                                                                                   | `1`                             |

--- a/charts/ndc-graphql/templates/secret.yaml
+++ b/charts/ndc-graphql/templates/secret.yaml
@@ -8,7 +8,3 @@ data:
   HASURA_SERVICE_TOKEN_SECRET: {{ required "Error: .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET is required!" .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET | b64enc | quote }}
   {{- end }}
   GRAPHQL_ENDPOINT: {{ required "Error: .Values.connectorEnvVars.GRAPHQL_ENDPOINT is required!" .Values.connectorEnvVars.GRAPHQL_ENDPOINT | b64enc | quote }}
-{{- if .Values.observability.enabled }}
-  otel-collector-config.yaml: {{ (tpl .Values.otel.config .) | b64enc | quote }}
-{{- end }}
-

--- a/charts/ndc-graphql/values.yaml
+++ b/charts/ndc-graphql/values.yaml
@@ -58,6 +58,7 @@ connectorEnvVars:
   GRAPHQL_ENDPOINT: ""
   configDirectory: ""
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  OTEL_SERVICE_NAME: ""
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -74,6 +75,13 @@ env: |
         name: {{ printf "%s-secret" (include "common.name" .) }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-graphql/values.yaml
+++ b/charts/ndc-graphql/values.yaml
@@ -8,8 +8,6 @@ image:
   repository: ""
   tag: ""
   pullPolicy: Always
-  otelCollectorRepository: otel/opentelemetry-collector-contrib
-  otelCollectorTag: 0.104.0
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:
@@ -47,94 +45,6 @@ hpa:
           type: Utilization
           averageUtilization: 80  # Target 80% memory utilization per pod
 
-# Observability defaults are tuned for Hasura hosted Control Plane
-observability:
-  enabled: false
-
-# Required (when observability.enabled is set to true)
-dataPlane:
-  id: ""
-  key: ""
-
-controlPlane:
-  otlpEndpoint: https://gateway.otlp.hasura.io:443
-  oauthTokenEndpoint: https://ddn-oauth.pro.hasura.io/oauth2/token
-
-otel:
-  config: |
-    extensions:
-      oauth2client:
-        client_id: {{ required "Error: .Values.dataPlane.id is required!" .Values.dataPlane.id }}
-        client_secret: {{ required "Error: .Values.dataPlane.key is required!" .Values.dataPlane.key }}
-        token_url: {{ .Values.controlPlane.oauthTokenEndpoint }}
-        scopes: ["opentelemetry:write"]
-        endpoint_params:
-          audience: https://ddn.hasura.io
-    exporters:
-      otlp/oauth:
-        endpoint: {{ .Values.controlPlane.otlpEndpoint }}
-        auth:
-          authenticator: oauth2client
-    processors:
-      batch: {}
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    service:
-      extensions: [oauth2client]
-      pipelines:
-        logs:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        metrics:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        traces:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-
-extraVolumes: |
-  {{- if .Values.observability.enabled }}
-  - name: otel-config
-    secret:
-      secretName: {{ printf "%s-secret" (include "common.name" .) }}
-      items:
-        - key: otel-collector-config.yaml
-          path: otel-collector-config.yaml
-  {{- end }}
-
-extraContainers: |
-  {{- if .Values.observability.enabled }}
-  - name: "otel-collector"
-    command:
-      - --config=/etc/otel-collector-config.yaml
-    command:
-    image: {{ template "common.image" (dict "Values" $.Values "repository" .Values.image.otelCollectorRepository "tag" .Values.image.otelCollectorTag) }}
-    env:
-    - name: "OTEL_ENDPOINT"
-      value: "{{ .Values.controlPlane.otlpEndpoint }}"
-    volumeMounts:
-      - name: otel-config
-        mountPath: "/etc/otelcol-contrib/config.yaml"
-        subPath: otel-collector-config.yaml
-  {{- end }}
-
 resources: |
   requests:
     cpu: "500m"
@@ -147,6 +57,7 @@ connectorEnvVars:
   HASURA_SERVICE_TOKEN_SECRET: ""
   GRAPHQL_ENDPOINT: ""
   configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -162,7 +73,7 @@ env: |
         key: GRAPHQL_ENDPOINT
         name: {{ printf "%s-secret" (include "common.name" .) }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: http://localhost:4317
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-jvm-mysql/Chart.yaml
+++ b/charts/ndc-jvm-mysql/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.04.03
+version: v2025.04.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-jvm-mysql/README.md
+++ b/charts/ndc-jvm-mysql/README.md
@@ -64,7 +64,10 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.JDBC_URL`                       | The JDBC URL to connect to the database (Required)                                                                         | `""`                                 |
 | `connectorEnvVars.JDBC_SCHEMAS`                   | A comma-separated list of schemas to include in the metadata (Optional)                                                                         | `""`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
-| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`                   | Sets the OTLP endpoint to send telemetry data (traces) (Optional)                                                                         | `"http://dp-otel-collector:4317"`                                 |
+| `connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`                   | Sets the OTLP endpoint to send telemetry data (metrics)(Optional)                                                                         | `"http://dp-otel-collector:4317"`                                 |
+| `connectorEnvVars.QUARKUS_OTEL_SERVICE_NAME`           | Sets OTEL Service Name (Optional)                                                                         | `"ndc-jvm-mysql"`                                 |
+| `connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING`                   | Enable or disable tracing for JDBC connections (Optional)                                                                         | `true`                                 |
 
 ## Additional Parameters
 

--- a/charts/ndc-jvm-mysql/README.md
+++ b/charts/ndc-jvm-mysql/README.md
@@ -64,6 +64,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.JDBC_URL`                       | The JDBC URL to connect to the database (Required)                                                                         | `""`                                 |
 | `connectorEnvVars.JDBC_SCHEMAS`                   | A comma-separated list of schemas to include in the metadata (Optional)                                                                         | `""`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
 
 ## Additional Parameters
 
@@ -73,15 +74,6 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `image.repository`                                | Image repository containing custom created ndc-jvm-mysql                                                    | `""`                                |
 | `image.tag`                                       | Image tag to use for custom created ndc-jvm-mysql                                                           | `""`                                |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                            |
-| `image.otelCollectorRepository`                   | OTEL collector image repository                                                                            | `otel/opentelemetry-collector`      |
-| `image.otelCollectorTag`                          | OTEL collector image tag                                                                                   | `0.104.0`                           |
-| `observability.enabled`                           | Deploy OTEL collector as sidecar                                                                           | `true`                          |
-| `dataPlane.id`                                    | Data Plane ID (Required when observability.enabled is set to true)                                         | `""`                         |
-| `dataPlane.key`                                   | Data Plane Key (Required when observability.enabled is set to true)                                        | `""`                         |
-| `controlPlane.otlpEndpoint`                       | OTEL endpoint under Hasura                                                                                 | `"https://gateway.otlp.hasura.io:443"`                         |
-| `controlPlane.oauthTokenEndpoint`                 | Oauth Token URL                                                                                            | `"https://ddn-oauth.pro.hasura.io/oauth2/token"`                         |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the ndc-jvm-mysql pod                                | `[]`                                |
-| `extraContainers`                                 | Optionally specify extra list of additional containers for the ndc-jvm-mysql pod                             | `[]`                                |
 | `resources`                                       | Resource requests and limits of ndc-jvm-mysql container                                                      | `{}`                                |
 | `env`                                             | Env variable section for ndc-jvm-mysql                                                                      | `[]`                                |
 | `replicas`                                        | Replicas setting for pod                                                                                   | `1`                                 |

--- a/charts/ndc-jvm-mysql/templates/secret.yaml
+++ b/charts/ndc-jvm-mysql/templates/secret.yaml
@@ -8,6 +8,3 @@ data:
   HASURA_SERVICE_TOKEN_SECRET: {{ required "Error: .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET is required!" .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET | b64enc | quote }}
   {{- end }}
   JDBC_URL: {{ required "Error: .Values.connectorEnvVars.JDBC_URL is required!" .Values.connectorEnvVars.JDBC_URL | b64enc | quote }}
-{{- if .Values.observability.enabled }}
-  otel-collector-config.yaml: {{ (tpl .Values.otel.config .) | b64enc | quote }}
-{{- end }}

--- a/charts/ndc-jvm-mysql/values.yaml
+++ b/charts/ndc-jvm-mysql/values.yaml
@@ -58,7 +58,10 @@ connectorEnvVars:
   JDBC_URL: ""
   JDBC_SCHEMAS: ""
   configDirectory: ""
-  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://dp-otel-collector:4317"
+  QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "http://dp-otel-collector:4317"
+  QUARKUS_OTEL_SERVICE_NAME: ""
+  QUARKUS_DATASOURCE_JDBC_TRACING: true
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -77,8 +80,25 @@ env: |
   - name: JDBC_SCHEMAS
     value: {{ .Values.connectorEnvVars.JDBC_SCHEMAS | quote }}
   {{- end }}
-  - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}
+  - name: QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    value: {{ .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT }}
+  - name: QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+    value: {{ .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.QUARKUS_OTEL_SERVICE_NAME }}
+  - name: QUARKUS_OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.QUARKUS_OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: QUARKUS_OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING }}
+  - name: QUARKUS_DATASOURCE_JDBC_TRACING
+    value: {{ .Values.connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING | quote }}
+  {{- end }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-jvm-mysql/values.yaml
+++ b/charts/ndc-jvm-mysql/values.yaml
@@ -8,8 +8,6 @@ image:
   repository: ""
   tag: ""
   pullPolicy: Always
-  otelCollectorRepository: otel/opentelemetry-collector-contrib
-  otelCollectorTag: 0.104.0
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:
@@ -47,94 +45,6 @@ hpa:
           type: Utilization
           averageUtilization: 80  # Target 80% memory utilization per pod
 
-# Observability defaults are tuned for Hasura hosted Control Plane
-observability:
-  enabled: false
-
-# Required (when observability.enabled is set to true)
-dataPlane:
-  id: ""
-  key: ""
-
-controlPlane:
-  otlpEndpoint: https://gateway.otlp.hasura.io:443
-  oauthTokenEndpoint: https://ddn-oauth.pro.hasura.io/oauth2/token
-
-otel:
-  config: |
-    extensions:
-      oauth2client:
-        client_id: {{ required "Error: .Values.dataPlane.id is required!" .Values.dataPlane.id }}
-        client_secret: {{ required "Error: .Values.dataPlane.key is required!" .Values.dataPlane.key }}
-        token_url: {{ .Values.controlPlane.oauthTokenEndpoint }}
-        scopes: ["opentelemetry:write"]
-        endpoint_params:
-          audience: https://ddn.hasura.io
-    exporters:
-      otlp/oauth:
-        endpoint: {{ .Values.controlPlane.otlpEndpoint }}
-        auth:
-          authenticator: oauth2client
-    processors:
-      batch: {}
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    service:
-      extensions: [oauth2client]
-      pipelines:
-        logs:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        metrics:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        traces:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-
-extraVolumes: |
-  {{- if .Values.observability.enabled }}
-  - name: otel-config
-    secret:
-      secretName: {{ printf "%s-secret" (include "common.name" .) }}
-      items:
-        - key: otel-collector-config.yaml
-          path: otel-collector-config.yaml
-  {{- end }}
-
-extraContainers: |
-  {{- if .Values.observability.enabled }}
-  - name: "otel-collector"
-    command:
-      - --config=/etc/otel-collector-config.yaml
-    command:
-    image: {{ template "common.image" (dict "Values" $.Values "repository" .Values.image.otelCollectorRepository "tag" .Values.image.otelCollectorTag) }}
-    env:
-    - name: "OTEL_ENDPOINT"
-      value: "{{ .Values.controlPlane.otlpEndpoint }}"
-    volumeMounts:
-      - name: otel-config
-        mountPath: "/etc/otelcol-contrib/config.yaml"
-        subPath: otel-collector-config.yaml
-  {{- end }}
-
 resources: |
   requests:
     cpu: "500m"
@@ -148,6 +58,7 @@ connectorEnvVars:
   JDBC_URL: ""
   JDBC_SCHEMAS: ""
   configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -167,7 +78,7 @@ env: |
     value: {{ .Values.connectorEnvVars.JDBC_SCHEMAS | quote }}
   {{- end }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: http://localhost:4317
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-mongodb/Chart.yaml
+++ b/charts/ndc-mongodb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.04.03
+version: v2025.04.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-mongodb/README.md
+++ b/charts/ndc-mongodb/README.md
@@ -63,6 +63,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET`    | Hasura Service Token Secret (Optional)                                                                     | `""`                                 |
 | `connectorEnvVars.MONGODB_DATABASE_URI`           | Database Connection URI (Required)                                                                         | `""`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
 
 ## Additional Parameters
 
@@ -72,15 +73,6 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `image.repository`                                | Image repository containing custom created ndc-mongodb                                                     | `""`                                |
 | `image.tag`                                       | Image tag to use for custom created ndc-mongodb                                                            | `""`                                |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                            |
-| `image.otelCollectorRepository`                   | OTEL collector image repository                                                                            | `otel/opentelemetry-collector`      |
-| `image.otelCollectorTag`                          | OTEL collector image tag                                                                                   | `0.104.0`                           |
-| `observability.enabled`                           | Deploy OTEL collector as sidecar                                                                           | `false`                          |
-| `dataPlane.id`                                    | Data Plane ID (Required when observability.enabled is set to true)                                         | `""`                         |
-| `dataPlane.key`                                   | Data Plane Key (Required when observability.enabled is set to true)                                        | `""`                         |
-| `controlPlane.otlpEndpoint`                       | OTEL endpoint under Hasura                                                                                 | `"https://gateway.otlp.hasura.io:443"`                         |
-| `controlPlane.oauthTokenEndpoint`                 | Oauth Token URL                                                                                            | `"https://ddn-oauth.pro.hasura.io/oauth2/token"`                         |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the ndc-mongodb pod                                | `[]`                                |
-| `extraContainers`                                 | Optionally specify extra list of additional containers for the ndc-mongodb pod                             | `[]`                                |
 | `resources`                                       | Resource requests and limits of ndc-mongodb container                                                      | `{}`                                |
 | `env`                                             | Env variable section for ndc-mongodb                                                                       | `[]`                                |
 | `replicas`                                        | Replicas setting for pod                                                                                   | `1`                                 |

--- a/charts/ndc-mongodb/README.md
+++ b/charts/ndc-mongodb/README.md
@@ -64,6 +64,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.MONGODB_DATABASE_URI`           | Database Connection URI (Required)                                                                         | `""`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
 | `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.OTEL_SERVICE_NAME`              | OTEL Service Name (Optional)                                                                               | `ndc-mongodb`                  |
 
 ## Additional Parameters
 

--- a/charts/ndc-mongodb/templates/secret.yaml
+++ b/charts/ndc-mongodb/templates/secret.yaml
@@ -8,6 +8,3 @@ data:
   HASURA_SERVICE_TOKEN_SECRET: {{ required "Error: .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET is required!" .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET | b64enc | quote }}
   {{- end }}
   MONGODB_DATABASE_URI: {{ required "Error: .Values.connectorEnvVars.MONGODB_DATABASE_URI is required!" .Values.connectorEnvVars.MONGODB_DATABASE_URI | b64enc | quote }}
-{{- if .Values.observability.enabled }}
-  otel-collector-config.yaml: {{ (tpl .Values.otel.config .) | b64enc | quote }}
-{{- end }}

--- a/charts/ndc-mongodb/values.yaml
+++ b/charts/ndc-mongodb/values.yaml
@@ -58,6 +58,7 @@ connectorEnvVars:
   MONGODB_DATABASE_URI: ""
   configDirectory: ""
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  OTEL_SERVICE_NAME: ""
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -74,6 +75,13 @@ env: |
         name: {{ printf "%s-secret" (include "common.name" .) }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-mongodb/values.yaml
+++ b/charts/ndc-mongodb/values.yaml
@@ -8,8 +8,6 @@ image:
   repository: ""
   tag: ""
   pullPolicy: Always
-  otelCollectorRepository: otel/opentelemetry-collector-contrib
-  otelCollectorTag: 0.104.0
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:
@@ -47,94 +45,6 @@ hpa:
           type: Utilization
           averageUtilization: 80  # Target 80% memory utilization per pod
 
-# Observability defaults are tuned for Hasura hosted Control Plane
-observability:
-  enabled: false
-
-# Required (when observability.enabled is set to true)
-dataPlane:
-  id: ""
-  key: ""
-
-controlPlane:
-  otlpEndpoint: https://gateway.otlp.hasura.io:443
-  oauthTokenEndpoint: https://ddn-oauth.pro.hasura.io/oauth2/token
-
-otel:
-  config: |
-    extensions:
-      oauth2client:
-        client_id: {{ required "Error: .Values.dataPlane.id is required!" .Values.dataPlane.id }}
-        client_secret: {{ required "Error: .Values.dataPlane.key is required!" .Values.dataPlane.key }}
-        token_url: {{ .Values.controlPlane.oauthTokenEndpoint }}
-        scopes: ["opentelemetry:write"]
-        endpoint_params:
-          audience: https://ddn.hasura.io
-    exporters:
-      otlp/oauth:
-        endpoint: {{ .Values.controlPlane.otlpEndpoint }}
-        auth:
-          authenticator: oauth2client
-    processors:
-      batch: {}
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    service:
-      extensions: [oauth2client]
-      pipelines:
-        logs:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        metrics:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        traces:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-
-extraVolumes: |
-  {{- if .Values.observability.enabled }}
-  - name: otel-config
-    secret:
-      secretName: {{ printf "%s-secret" (include "common.name" .) }}
-      items:
-        - key: otel-collector-config.yaml
-          path: otel-collector-config.yaml
-  {{- end }}
-
-extraContainers: |
-  {{- if .Values.observability.enabled }}
-  - name: "otel-collector"
-    command:
-      - --config=/etc/otel-collector-config.yaml
-    command:
-    image: {{ template "common.image" (dict "Values" $.Values "repository" .Values.image.otelCollectorRepository "tag" .Values.image.otelCollectorTag) }}
-    env:
-    - name: "OTEL_ENDPOINT"
-      value: "{{ .Values.controlPlane.otlpEndpoint }}"
-    volumeMounts:
-      - name: otel-config
-        mountPath: "/etc/otelcol-contrib/config.yaml"
-        subPath: otel-collector-config.yaml
-  {{- end }}
-
 resources: |
   requests:
     cpu: "500m"
@@ -147,6 +57,7 @@ connectorEnvVars:
   HASURA_SERVICE_TOKEN_SECRET: ""
   MONGODB_DATABASE_URI: ""
   configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -162,7 +73,7 @@ env: |
         key: MONGODB_DATABASE_URI
         name: {{ printf "%s-secret" (include "common.name" .) }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: http://localhost:4317
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-mysql-jdbc/Chart.yaml
+++ b/charts/ndc-mysql-jdbc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.04.14
+version: v2025.04.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-mysql-jdbc/README.md
+++ b/charts/ndc-mysql-jdbc/README.md
@@ -63,6 +63,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET`    | Hasura Service Token Secret (Optional)                                                                     | `""`                                 |
 | `connectorEnvVars.JDBC_URL`                       | The JDBC URL to connect to the database (Required)                                                                         | `""`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
 
 ## Additional Parameters
 
@@ -72,15 +73,6 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `image.repository`                                | Image repository containing custom created ndc-mysql-jdbc                                                    | `""`                                |
 | `image.tag`                                       | Image tag to use for custom created ndc-mysql-jdbc                                                           | `""`                                |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                            |
-| `image.otelCollectorRepository`                   | OTEL collector image repository                                                                            | `otel/opentelemetry-collector`      |
-| `image.otelCollectorTag`                          | OTEL collector image tag                                                                                   | `0.104.0`                           |
-| `observability.enabled`                           | Deploy OTEL collector as sidecar                                                                           | `true`                          |
-| `dataPlane.id`                                    | Data Plane ID (Required when observability.enabled is set to true)                                         | `""`                         |
-| `dataPlane.key`                                   | Data Plane Key (Required when observability.enabled is set to true)                                        | `""`                         |
-| `controlPlane.otlpEndpoint`                       | OTEL endpoint under Hasura                                                                                 | `"https://gateway.otlp.hasura.io:443"`                         |
-| `controlPlane.oauthTokenEndpoint`                 | Oauth Token URL                                                                                            | `"https://ddn-oauth.pro.hasura.io/oauth2/token"`                         |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the ndc-mysql-jdbc pod                                | `[]`                                |
-| `extraContainers`                                 | Optionally specify extra list of additional containers for the ndc-mysql-jdbc pod                             | `[]`                                |
 | `resources`                                       | Resource requests and limits of ndc-mysql-jdbc container                                                      | `{}`                                |
 | `env`                                             | Env variable section for ndc-mysql-jdbc                                                                      | `[]`                                |
 | `replicas`                                        | Replicas setting for pod                                                                                   | `1`                                 |

--- a/charts/ndc-mysql-jdbc/README.md
+++ b/charts/ndc-mysql-jdbc/README.md
@@ -64,6 +64,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.JDBC_URL`                       | The JDBC URL to connect to the database (Required)                                                                         | `""`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
 | `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.OTEL_SERVICE_NAME`              | OTEL Service Name (Optional)                                                                               | `ndc-mysql-jdbc`                  |
 
 ## Additional Parameters
 

--- a/charts/ndc-mysql-jdbc/templates/secret.yaml
+++ b/charts/ndc-mysql-jdbc/templates/secret.yaml
@@ -8,6 +8,3 @@ data:
   HASURA_SERVICE_TOKEN_SECRET: {{ required "Error: .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET is required!" .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET | b64enc | quote }}
   {{- end }}
   JDBC_URL: {{ required "Error: .Values.connectorEnvVars.JDBC_URL is required!" .Values.connectorEnvVars.JDBC_URL | b64enc | quote }}
-{{- if .Values.observability.enabled }}
-  otel-collector-config.yaml: {{ (tpl .Values.otel.config .) | b64enc | quote }}
-{{- end }}

--- a/charts/ndc-mysql-jdbc/values.yaml
+++ b/charts/ndc-mysql-jdbc/values.yaml
@@ -58,6 +58,7 @@ connectorEnvVars:
   JDBC_URL: ""
   configDirectory: ""
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  OTEL_SERVICE_NAME: ""
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -74,6 +75,13 @@ env: |
         name: {{ printf "%s-secret" (include "common.name" .) }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-mysql-jdbc/values.yaml
+++ b/charts/ndc-mysql-jdbc/values.yaml
@@ -8,8 +8,6 @@ image:
   repository: ""
   tag: ""
   pullPolicy: Always
-  otelCollectorRepository: otel/opentelemetry-collector-contrib
-  otelCollectorTag: 0.104.0
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:
@@ -47,94 +45,6 @@ hpa:
           type: Utilization
           averageUtilization: 80  # Target 80% memory utilization per pod
 
-# Observability defaults are tuned for Hasura hosted Control Plane
-observability:
-  enabled: false
-
-# Required (when observability.enabled is set to true)
-dataPlane:
-  id: ""
-  key: ""
-
-controlPlane:
-  otlpEndpoint: https://gateway.otlp.hasura.io:443
-  oauthTokenEndpoint: https://ddn-oauth.pro.hasura.io/oauth2/token
-
-otel:
-  config: |
-    extensions:
-      oauth2client:
-        client_id: {{ required "Error: .Values.dataPlane.id is required!" .Values.dataPlane.id }}
-        client_secret: {{ required "Error: .Values.dataPlane.key is required!" .Values.dataPlane.key }}
-        token_url: {{ .Values.controlPlane.oauthTokenEndpoint }}
-        scopes: ["opentelemetry:write"]
-        endpoint_params:
-          audience: https://ddn.hasura.io
-    exporters:
-      otlp/oauth:
-        endpoint: {{ .Values.controlPlane.otlpEndpoint }}
-        auth:
-          authenticator: oauth2client
-    processors:
-      batch: {}
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    service:
-      extensions: [oauth2client]
-      pipelines:
-        logs:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        metrics:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        traces:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-
-extraVolumes: |
-  {{- if .Values.observability.enabled }}
-  - name: otel-config
-    secret:
-      secretName: {{ printf "%s-secret" (include "common.name" .) }}
-      items:
-        - key: otel-collector-config.yaml
-          path: otel-collector-config.yaml
-  {{- end }}
-
-extraContainers: |
-  {{- if .Values.observability.enabled }}
-  - name: "otel-collector"
-    command:
-      - --config=/etc/otel-collector-config.yaml
-    command:
-    image: {{ template "common.image" (dict "Values" $.Values "repository" .Values.image.otelCollectorRepository "tag" .Values.image.otelCollectorTag) }}
-    env:
-    - name: "OTEL_ENDPOINT"
-      value: "{{ .Values.controlPlane.otlpEndpoint }}"
-    volumeMounts:
-      - name: otel-config
-        mountPath: "/etc/otelcol-contrib/config.yaml"
-        subPath: otel-collector-config.yaml
-  {{- end }}
-
 resources: |
   requests:
     cpu: "500m"
@@ -147,6 +57,7 @@ connectorEnvVars:
   HASURA_SERVICE_TOKEN_SECRET: ""
   JDBC_URL: ""
   configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -162,7 +73,7 @@ env: |
         key: JDBC_URL
         name: {{ printf "%s-secret" (include "common.name" .) }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: http://localhost:4317
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-nodejs-lambda/Chart.yaml
+++ b/charts/ndc-nodejs-lambda/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.04.03
+version: v2025.04.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-nodejs-lambda/README.md
+++ b/charts/ndc-nodejs-lambda/README.md
@@ -60,6 +60,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET`    | Hasura Service Token Secret (Optional)                                                                     | `""`                            |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
 | `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.OTEL_SERVICE_NAME`              | OTEL Service Name (Optional)                                                                               | `ndc-nodejs-lambda`                  |
 
 ## Additional Parameters
 

--- a/charts/ndc-nodejs-lambda/README.md
+++ b/charts/ndc-nodejs-lambda/README.md
@@ -59,6 +59,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------- |
 | `connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET`    | Hasura Service Token Secret (Optional)                                                                     | `""`                            |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
 
 ## Additional Parameters
 
@@ -68,15 +69,6 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `image.repository`                                | Image repository containing custom created ndc-nodejs-lambda                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-nodejs-lambda                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |
-| `image.otelCollectorRepository`                   | OTEL collector image repository                                                                            | `otel/opentelemetry-collector`  |
-| `image.otelCollectorTag`                          | OTEL collector image tag                                                                                   | `0.104.0`                       |
-| `observability.enabled`                           | Deploy OTEL collector as sidecar                                                                           | `true`                          |
-| `dataPlane.id`                                    | Data Plane ID (Required when observability.enabled is set to true)                                         | `""`                         |
-| `dataPlane.key`                                   | Data Plane Key (Required when observability.enabled is set to true)                                        | `""`                         |
-| `controlPlane.otlpEndpoint`                       | OTEL endpoint under Hasura                                                                                 | `"https://gateway.otlp.hasura.io:443"`                         |
-| `controlPlane.oauthTokenEndpoint`                 | Oauth Token URL                                                                                            | `"https://ddn-oauth.pro.hasura.io/oauth2/token"`                         |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the ndc-nodejs-lambda pod                               | `[]`                            |
-| `extraContainers`                                 | Optionally specify extra list of additional containers for the ndc-nodejs-lambda pod                            | `[]`                               |                               |
 | `resources`                                       | Resource requests and limits of ndc-nodejs-lambda container                                                     | `{}`                            |
 | `env`                                             | Env variable section for ndc-nodejs-lambda                                                                      | `[]`                            |
 | `replicas`                                        | Replicas setting for pod                                                                                   | `1`                             |

--- a/charts/ndc-nodejs-lambda/templates/secret.yaml
+++ b/charts/ndc-nodejs-lambda/templates/secret.yaml
@@ -7,6 +7,3 @@ data:
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
   HASURA_SERVICE_TOKEN_SECRET: {{ required "Error: .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET is required!" .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET | b64enc | quote }}
   {{- end }}
-{{- if .Values.observability.enabled }}
-  otel-collector-config.yaml: {{ (tpl .Values.otel.config .) | b64enc | quote }}
-{{- end }}

--- a/charts/ndc-nodejs-lambda/values.yaml
+++ b/charts/ndc-nodejs-lambda/values.yaml
@@ -8,8 +8,6 @@ image:
   repository: ""
   tag: ""
   pullPolicy: Always
-  otelCollectorRepository: otel/opentelemetry-collector-contrib
-  otelCollectorTag: 0.104.0
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:
@@ -47,94 +45,6 @@ hpa:
           type: Utilization
           averageUtilization: 80  # Target 80% memory utilization per pod
 
-# Observability defaults are tuned for Hasura hosted Control Plane
-observability:
-  enabled: false
-
-# Required (when observability.enabled is set to true)
-dataPlane:
-  id: ""
-  key: ""
-
-controlPlane:
-  otlpEndpoint: https://gateway.otlp.hasura.io:443
-  oauthTokenEndpoint: https://ddn-oauth.pro.hasura.io/oauth2/token
-
-otel:
-  config: |
-    extensions:
-      oauth2client:
-        client_id: {{ required "Error: .Values.dataPlane.id is required!" .Values.dataPlane.id }}
-        client_secret: {{ required "Error: .Values.dataPlane.key is required!" .Values.dataPlane.key }}
-        token_url: {{ .Values.controlPlane.oauthTokenEndpoint }}
-        scopes: ["opentelemetry:write"]
-        endpoint_params:
-          audience: https://ddn.hasura.io
-    exporters:
-      otlp/oauth:
-        endpoint: {{ .Values.controlPlane.otlpEndpoint }}
-        auth:
-          authenticator: oauth2client
-    processors:
-      batch: {}
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    service:
-      extensions: [oauth2client]
-      pipelines:
-        logs:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        metrics:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        traces:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-
-extraVolumes: |
-  {{- if .Values.observability.enabled }}
-  - name: otel-config
-    secret:
-      secretName: {{ printf "%s-secret" (include "common.name" .) }}
-      items:
-        - key: otel-collector-config.yaml
-          path: otel-collector-config.yaml
-  {{- end }}
-
-extraContainers: |
-  {{- if .Values.observability.enabled }}
-  - name: "otel-collector"
-    command:
-      - --config=/etc/otel-collector-config.yaml
-    command:
-    image: {{ template "common.image" (dict "Values" $.Values "repository" .Values.image.otelCollectorRepository "tag" .Values.image.otelCollectorTag) }}
-    env:
-    - name: "OTEL_ENDPOINT"
-      value: "{{ .Values.controlPlane.otlpEndpoint }}"
-    volumeMounts:
-      - name: otel-config
-        mountPath: "/etc/otelcol-contrib/config.yaml"
-        subPath: otel-collector-config.yaml
-  {{- end }}
-
 resources: |
   requests:
     cpu: "500m"
@@ -146,6 +56,7 @@ resources: |
 connectorEnvVars:
   HASURA_SERVICE_TOKEN_SECRET: ""
   configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -156,7 +67,7 @@ env: |
         name: {{ printf "%s-secret" (include "common.name" .) }}
   {{- end }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: http://localhost:4317
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-nodejs-lambda/values.yaml
+++ b/charts/ndc-nodejs-lambda/values.yaml
@@ -57,6 +57,7 @@ connectorEnvVars:
   HASURA_SERVICE_TOKEN_SECRET: ""
   configDirectory: ""
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  OTEL_SERVICE_NAME: ""
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -68,6 +69,13 @@ env: |
   {{- end }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-open-api-lambda/Chart.yaml
+++ b/charts/ndc-open-api-lambda/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.04.03
+version: v2025.04.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-open-api-lambda/README.md
+++ b/charts/ndc-open-api-lambda/README.md
@@ -66,6 +66,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.NDC_OAS_LAMBDA_PRETTY_LOGS`     | Print logs in a human readable format instead of JSON (Optional)                                          | `"true"`                            |
 | `connectorEnvVars.NDC_OAS_FILE_OVERWRITE`         | Overwrite previously generated functions.ts file and api.ts file (Optional)                               | `"false"`                            |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
 
 ## Additional Parameters
 
@@ -75,15 +76,6 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `image.repository`                                | Image repository containing custom created ndc-open-api-lambda                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-open-api-lambda                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |
-| `image.otelCollectorRepository`                   | OTEL collector image repository                                                                            | `otel/opentelemetry-collector`  |
-| `image.otelCollectorTag`                          | OTEL collector image tag                                                                                   | `0.104.0`                       |
-| `observability.enabled`                           | Deploy OTEL collector as sidecar                                                                           | `true`                          |
-| `dataPlane.id`                                    | Data Plane ID (Required when observability.enabled is set to true)                                         | `""`                         |
-| `dataPlane.key`                                   | Data Plane Key (Required when observability.enabled is set to true)                                        | `""`                         |
-| `controlPlane.otlpEndpoint`                       | OTEL endpoint under Hasura                                                                                 | `"https://gateway.otlp.hasura.io:443"`                         |
-| `controlPlane.oauthTokenEndpoint`                 | Oauth Token URL                                                                                            | `"https://ddn-oauth.pro.hasura.io/oauth2/token"`                         |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the ndc-open-api-lambda pod                               | `[]`                            |
-| `extraContainers`                                 | Optionally specify extra list of additional containers for the ndc-open-api-lambda pod                            | `[]`                               |                               |
 | `resources`                                       | Resource requests and limits of ndc-open-api-lambda container                                                     | `{}`                            |
 | `env`                                             | Env variable section for ndc-open-api-lambda                                                                      | `[]`                            |
 | `replicas`                                        | Replicas setting for pod                                                                                   | `1`                             |

--- a/charts/ndc-open-api-lambda/README.md
+++ b/charts/ndc-open-api-lambda/README.md
@@ -67,6 +67,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.NDC_OAS_FILE_OVERWRITE`         | Overwrite previously generated functions.ts file and api.ts file (Optional)                               | `"false"`                            |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
 | `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.OTEL_SERVICE_NAME`              | OTEL Service Name (Optional)                                                                               | `ndc-open-api-lambda`                  |
 
 ## Additional Parameters
 

--- a/charts/ndc-open-api-lambda/templates/secret.yaml
+++ b/charts/ndc-open-api-lambda/templates/secret.yaml
@@ -13,6 +13,3 @@ data:
   NDC_OAS_BASE_URL: {{ required "Error: .Values.connectorEnvVars.NDC_OAS_BASE_URL is required!" .Values.connectorEnvVars.NDC_OAS_BASE_URL | b64enc | quote }}
   NDC_OAS_LAMBDA_PRETTY_LOGS: {{ required "Error: .Values.connectorEnvVars.NDC_OAS_LAMBDA_PRETTY_LOGS is required!" .Values.connectorEnvVars.NDC_OAS_LAMBDA_PRETTY_LOGS | toString | b64enc }}
   NDC_OAS_FILE_OVERWRITE: {{ required "Error: .Values.connectorEnvVars.NDC_OAS_FILE_OVERWRITE is required!" .Values.connectorEnvVars.NDC_OAS_FILE_OVERWRITE | toString | b64enc }}
-  {{- if .Values.observability.enabled }}
-  otel-collector-config.yaml: {{ (tpl .Values.otel.config .) | b64enc | quote }}
-  {{- end }}

--- a/charts/ndc-open-api-lambda/values.yaml
+++ b/charts/ndc-open-api-lambda/values.yaml
@@ -61,6 +61,7 @@ connectorEnvVars:
   NDC_OAS_FILE_OVERWRITE: "false"
   configDirectory: ""
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  OTEL_SERVICE_NAME: ""
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -94,6 +95,13 @@ env: |
         name: {{ printf "%s-secret" (include "common.name" .) }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-open-api-lambda/values.yaml
+++ b/charts/ndc-open-api-lambda/values.yaml
@@ -8,8 +8,6 @@ image:
   repository: ""
   tag: ""
   pullPolicy: Always
-  otelCollectorRepository: otel/opentelemetry-collector-contrib
-  otelCollectorTag: 0.104.0
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:
@@ -47,94 +45,6 @@ hpa:
           type: Utilization
           averageUtilization: 80  # Target 80% memory utilization per pod
 
-# Observability defaults are tuned for Hasura hosted Control Plane
-observability:
-  enabled: false
-
-# Required (when observability.enabled is set to true)
-dataPlane:
-  id: ""
-  key: ""
-
-controlPlane:
-  otlpEndpoint: https://gateway.otlp.hasura.io:443
-  oauthTokenEndpoint: https://ddn-oauth.pro.hasura.io/oauth2/token
-
-otel:
-  config: |
-    extensions:
-      oauth2client:
-        client_id: {{ required "Error: .Values.dataPlane.id is required!" .Values.dataPlane.id }}
-        client_secret: {{ required "Error: .Values.dataPlane.key is required!" .Values.dataPlane.key }}
-        token_url: {{ .Values.controlPlane.oauthTokenEndpoint }}
-        scopes: ["opentelemetry:write"]
-        endpoint_params:
-          audience: https://ddn.hasura.io
-    exporters:
-      otlp/oauth:
-        endpoint: {{ .Values.controlPlane.otlpEndpoint }}
-        auth:
-          authenticator: oauth2client
-    processors:
-      batch: {}
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    service:
-      extensions: [oauth2client]
-      pipelines:
-        logs:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        metrics:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        traces:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-
-extraVolumes: |
-  {{- if .Values.observability.enabled }}
-  - name: otel-config
-    secret:
-      secretName: {{ printf "%s-secret" (include "common.name" .) }}
-      items:
-        - key: otel-collector-config.yaml
-          path: otel-collector-config.yaml
-  {{- end }}
-
-extraContainers: |
-  {{- if .Values.observability.enabled }}
-  - name: "otel-collector"
-    command:
-      - --config=/etc/otel-collector-config.yaml
-    command:
-    image: {{ template "common.image" (dict "Values" $.Values "repository" .Values.image.otelCollectorRepository "tag" .Values.image.otelCollectorTag) }}
-    env:
-    - name: "OTEL_ENDPOINT"
-      value: "{{ .Values.controlPlane.otlpEndpoint }}"
-    volumeMounts:
-      - name: otel-config
-        mountPath: "/etc/otelcol-contrib/config.yaml"
-        subPath: otel-collector-config.yaml
-  {{- end }}
-
 resources: |
   requests:
     cpu: "500m"
@@ -150,6 +60,7 @@ connectorEnvVars:
   NDC_OAS_LAMBDA_PRETTY_LOGS: "true"
   NDC_OAS_FILE_OVERWRITE: "false"
   configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -182,7 +93,7 @@ env: |
         key: NDC_OAS_FILE_OVERWRITE
         name: {{ printf "%s-secret" (include "common.name" .) }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: http://localhost:4317
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-postgres-jdbc/Chart.yaml
+++ b/charts/ndc-postgres-jdbc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.04.15
+version: v2025.04.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-postgres-jdbc/README.md
+++ b/charts/ndc-postgres-jdbc/README.md
@@ -65,6 +65,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.JDBC_SCHEMAS`                   | A comma-separated list of schemas to include in the metadata (Optional)                                                                         | `""`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
 | `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.OTEL_SERVICE_NAME`              | OTEL Service Name (Optional)                                                                               | `ndc-postgres-jdbc`                  |
 
 ## Additional Parameters
 

--- a/charts/ndc-postgres-jdbc/README.md
+++ b/charts/ndc-postgres-jdbc/README.md
@@ -64,6 +64,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.JDBC_URL`                 | The JDBC URL to connect to the database (Required)                                                                         | `""`                            |
 | `connectorEnvVars.JDBC_SCHEMAS`                   | A comma-separated list of schemas to include in the metadata (Optional)                                                                         | `""`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
 
 ## Additional Parameters
 
@@ -73,15 +74,6 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `image.repository`                                | Image repository containing custom created ndc-postgres-jdbc                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-postgres-jdbc                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |
-| `image.otelCollectorRepository`                   | OTEL collector image repository                                                                            | `otel/opentelemetry-collector`  |
-| `image.otelCollectorTag`                          | OTEL collector image tag                                                                                   | `0.104.0`                       |
-| `observability.enabled`                           | Deploy OTEL collector as sidecar                                                                           | `false`                         |
-| `dataPlane.id`                                    | Data Plane ID (Required when observability.enabled is set to true)                                         | `""`                         |
-| `dataPlane.key`                                   | Data Plane Key (Required when observability.enabled is set to true)                                        | `""`                         |
-| `controlPlane.otlpEndpoint`                       | OTEL endpoint under Hasura                                                                                 | `"https://gateway.otlp.hasura.io:443"`                         |
-| `controlPlane.oauthTokenEndpoint`                 | Oauth Token URL                                                                                            | `"https://ddn-oauth.pro.hasura.io/oauth2/token"`                         |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the ndc-postgres-jdbc pod                               | `[]`                            |
-| `extraContainers`                                 | Optionally specify extra list of additional containers for the ndc-postgres-jdbc pod                            | `[]`                               |                               |
 | `resources`                                       | Resource requests and limits of ndc-postgres-jdbc container                                                     | `{}`                            |
 | `env`                                             | Env variable section for ndc-postgres-jdbc                                                                      | `[]`                            |
 | `replicas`                                        | Replicas setting for pod                                                                                   | `1`                             |

--- a/charts/ndc-postgres-jdbc/templates/secret.yaml
+++ b/charts/ndc-postgres-jdbc/templates/secret.yaml
@@ -8,6 +8,3 @@ data:
   HASURA_SERVICE_TOKEN_SECRET: {{ required "Error: .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET is required!" .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET | b64enc | quote }}
   {{- end }}
   JDBC_URL: {{ required "Error: .Values.connectorEnvVars.JDBC_URL is required!" .Values.connectorEnvVars.JDBC_URL | b64enc | quote }}
-{{- if .Values.observability.enabled }}
-  otel-collector-config.yaml: {{ (tpl .Values.otel.config .) | b64enc | quote }}
-{{- end }}

--- a/charts/ndc-postgres-jdbc/values.yaml
+++ b/charts/ndc-postgres-jdbc/values.yaml
@@ -8,8 +8,6 @@ image:
   repository: ""
   tag: ""
   pullPolicy: Always
-  otelCollectorRepository: otel/opentelemetry-collector-contrib
-  otelCollectorTag: 0.104.0
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:
@@ -47,94 +45,6 @@ hpa:
           type: Utilization
           averageUtilization: 80  # Target 80% memory utilization per pod
 
-# Observability defaults are tuned for Hasura hosted Control Plane
-observability:
-  enabled: false
-
-# Required (when observability.enabled is set to true)
-dataPlane:
-  id: ""
-  key: ""
-
-controlPlane:
-  otlpEndpoint: https://gateway.otlp.hasura.io:443
-  oauthTokenEndpoint: https://ddn-oauth.pro.hasura.io/oauth2/token
-
-otel:
-  config: |
-    extensions:
-      oauth2client:
-        client_id: {{ required "Error: .Values.dataPlane.id is required!" .Values.dataPlane.id }}
-        client_secret: {{ required "Error: .Values.dataPlane.key is required!" .Values.dataPlane.key }}
-        token_url: {{ .Values.controlPlane.oauthTokenEndpoint }}
-        scopes: ["opentelemetry:write"]
-        endpoint_params:
-          audience: https://ddn.hasura.io
-    exporters:
-      otlp/oauth:
-        endpoint: {{ .Values.controlPlane.otlpEndpoint }}
-        auth:
-          authenticator: oauth2client
-    processors:
-      batch: {}
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    service:
-      extensions: [oauth2client]
-      pipelines:
-        logs:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        metrics:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        traces:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-
-extraVolumes: |
-  {{- if .Values.observability.enabled }}
-  - name: otel-config
-    secret:
-      secretName: {{ printf "%s-secret" (include "common.name" .) }}
-      items:
-        - key: otel-collector-config.yaml
-          path: otel-collector-config.yaml
-  {{- end }}
-
-extraContainers: |
-  {{- if .Values.observability.enabled }}
-  - name: "otel-collector"
-    command:
-      - --config=/etc/otel-collector-config.yaml
-    command:
-    image: {{ template "common.image" (dict "Values" $.Values "repository" .Values.image.otelCollectorRepository "tag" .Values.image.otelCollectorTag) }}
-    env:
-    - name: "OTEL_ENDPOINT"
-      value: "{{ .Values.controlPlane.otlpEndpoint }}"
-    volumeMounts:
-      - name: otel-config
-        mountPath: "/etc/otelcol-contrib/config.yaml"
-        subPath: otel-collector-config.yaml
-  {{- end }}
-
 resources: |
   requests:
     cpu: "500m"
@@ -148,6 +58,7 @@ connectorEnvVars:
   JDBC_URL: ""
   JDBC_SCHEMAS: ""
   configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -167,7 +78,7 @@ env: |
     value: {{ .Values.connectorEnvVars.JDBC_SCHEMAS | quote }}
   {{- end }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: http://localhost:4317
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-postgres-jdbc/values.yaml
+++ b/charts/ndc-postgres-jdbc/values.yaml
@@ -59,6 +59,7 @@ connectorEnvVars:
   JDBC_SCHEMAS: ""
   configDirectory: ""
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  OTEL_SERVICE_NAME: ""
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -79,6 +80,13 @@ env: |
   {{- end }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-postgres/Chart.yaml
+++ b/charts/ndc-postgres/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.04.03
+version: v2025.04.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-postgres/README.md
+++ b/charts/ndc-postgres/README.md
@@ -67,6 +67,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.ROOT_CERT`                      | Database Root cert (Optional)                                                                              | `""`                            |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
 | `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.OTEL_SERVICE_NAME`              | OTEL Service Name (Optional)                                                                               | `ndc-postgres`                  |
 
 ## Additional Parameters
 

--- a/charts/ndc-postgres/README.md
+++ b/charts/ndc-postgres/README.md
@@ -66,6 +66,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.CLIENT_KEY`                     | Database Client key (Optional)                                                                             | `""`                            |
 | `connectorEnvVars.ROOT_CERT`                      | Database Root cert (Optional)                                                                              | `""`                            |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
 
 ## Additional Parameters
 
@@ -75,15 +76,6 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `image.repository`                                | Image repository containing custom created ndc-postgres                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-postgres                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |
-| `image.otelCollectorRepository`                   | OTEL collector image repository                                                                            | `otel/opentelemetry-collector`  |
-| `image.otelCollectorTag`                          | OTEL collector image tag                                                                                   | `0.104.0`                       |
-| `observability.enabled`                           | Deploy OTEL collector as sidecar                                                                           | `false`                         |
-| `dataPlane.id`                                    | Data Plane ID (Required when observability.enabled is set to true)                                         | `""`                         |
-| `dataPlane.key`                                   | Data Plane Key (Required when observability.enabled is set to true)                                        | `""`                         |
-| `controlPlane.otlpEndpoint`                       | OTEL endpoint under Hasura                                                                                 | `"https://gateway.otlp.hasura.io:443"`                         |
-| `controlPlane.oauthTokenEndpoint`                 | Oauth Token URL                                                                                            | `"https://ddn-oauth.pro.hasura.io/oauth2/token"`                         |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the ndc-postgres pod                               | `[]`                            |
-| `extraContainers`                                 | Optionally specify extra list of additional containers for the ndc-postgres pod                            | `[]`                               |                               |
 | `resources`                                       | Resource requests and limits of ndc-postgres container                                                     | `{}`                            |
 | `env`                                             | Env variable section for ndc-postgres                                                                      | `[]`                            |
 | `replicas`                                        | Replicas setting for pod                                                                                   | `1`                             |

--- a/charts/ndc-postgres/templates/secret.yaml
+++ b/charts/ndc-postgres/templates/secret.yaml
@@ -17,6 +17,3 @@ data:
   {{- if .Values.connectorEnvVars.ROOT_CERT }}
   ROOT_CERT: {{ .Values.connectorEnvVars.ROOT_CERT | b64enc | quote }}
   {{- end }}
-{{- if .Values.observability.enabled }}
-  otel-collector-config.yaml: {{ (tpl .Values.otel.config .) | b64enc | quote }}
-{{- end }}

--- a/charts/ndc-postgres/values.yaml
+++ b/charts/ndc-postgres/values.yaml
@@ -61,6 +61,7 @@ connectorEnvVars:
   ROOT_CERT: ""
   configDirectory: ""
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  OTEL_SERVICE_NAME: ""
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -98,6 +99,13 @@ env: |
   {{- end }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-postgres/values.yaml
+++ b/charts/ndc-postgres/values.yaml
@@ -8,8 +8,6 @@ image:
   repository: ""
   tag: ""
   pullPolicy: Always
-  otelCollectorRepository: otel/opentelemetry-collector-contrib
-  otelCollectorTag: 0.104.0
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:
@@ -47,94 +45,6 @@ hpa:
           type: Utilization
           averageUtilization: 80  # Target 80% memory utilization per pod
 
-# Observability defaults are tuned for Hasura hosted Control Plane
-observability:
-  enabled: false
-
-# Required (when observability.enabled is set to true)
-dataPlane:
-  id: ""
-  key: ""
-
-controlPlane:
-  otlpEndpoint: https://gateway.otlp.hasura.io:443
-  oauthTokenEndpoint: https://ddn-oauth.pro.hasura.io/oauth2/token
-
-otel:
-  config: |
-    extensions:
-      oauth2client:
-        client_id: {{ required "Error: .Values.dataPlane.id is required!" .Values.dataPlane.id }}
-        client_secret: {{ required "Error: .Values.dataPlane.key is required!" .Values.dataPlane.key }}
-        token_url: {{ .Values.controlPlane.oauthTokenEndpoint }}
-        scopes: ["opentelemetry:write"]
-        endpoint_params:
-          audience: https://ddn.hasura.io
-    exporters:
-      otlp/oauth:
-        endpoint: {{ .Values.controlPlane.otlpEndpoint }}
-        auth:
-          authenticator: oauth2client
-    processors:
-      batch: {}
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    service:
-      extensions: [oauth2client]
-      pipelines:
-        logs:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        metrics:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        traces:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-
-extraVolumes: |
-  {{- if .Values.observability.enabled }}
-  - name: otel-config
-    secret:
-      secretName: {{ printf "%s-secret" (include "common.name" .) }}
-      items:
-        - key: otel-collector-config.yaml
-          path: otel-collector-config.yaml
-  {{- end }}
-
-extraContainers: |
-  {{- if .Values.observability.enabled }}
-  - name: "otel-collector"
-    command:
-      - --config=/etc/otel-collector-config.yaml
-    command:
-    image: {{ template "common.image" (dict "Values" $.Values "repository" .Values.image.otelCollectorRepository "tag" .Values.image.otelCollectorTag) }}
-    env:
-    - name: "OTEL_ENDPOINT"
-      value: "{{ .Values.controlPlane.otlpEndpoint }}"
-    volumeMounts:
-      - name: otel-config
-        mountPath: "/etc/otelcol-contrib/config.yaml"
-        subPath: otel-collector-config.yaml
-  {{- end }}
-
 resources: |
   requests:
     cpu: "500m"
@@ -150,6 +60,7 @@ connectorEnvVars:
   CLIENT_KEY: ""
   ROOT_CERT: ""
   configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -186,7 +97,7 @@ env: |
         name: {{ printf "%s-secret" (include "common.name" .) }}
   {{- end }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: http://localhost:4317
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-snowflake-jdbc/Chart.yaml
+++ b/charts/ndc-snowflake-jdbc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.04.03
+version: v2025.04.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-snowflake-jdbc/README.md
+++ b/charts/ndc-snowflake-jdbc/README.md
@@ -64,6 +64,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.JDBC_URL`                       | The JDBC URL to connect to the database (Required)                                                                         | `""`                                 |
 | `connectorEnvVars.JDBC_SCHEMAS`                   | A comma-separated list of schemas to include in the metadata (Optional)                                                                         | `""`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
 
 ## Additional Parameters
 
@@ -73,15 +74,6 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `image.repository`                                | Image repository containing custom created ndc-snowflake-jdbc                                                     | `""`                                |
 | `image.tag`                                       | Image tag to use for custom created ndc-snowflake-jdbc                                                            | `""`                                |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                            |
-| `image.otelCollectorRepository`                   | OTEL collector image repository                                                                            | `otel/opentelemetry-collector`      |
-| `image.otelCollectorTag`                          | OTEL collector image tag                                                                                   | `0.104.0`                           |
-| `observability.enabled`                           | Deploy OTEL collector as sidecar                                                                           | `false`                          |
-| `dataPlane.id`                                    | Data Plane ID (Required when observability.enabled is set to true)                                         | `""`                         |
-| `dataPlane.key`                                   | Data Plane Key (Required when observability.enabled is set to true)                                        | `""`                         |
-| `controlPlane.otlpEndpoint`                       | OTEL endpoint under Hasura                                                                                 | `"https://gateway.otlp.hasura.io:443"`                         |
-| `controlPlane.oauthTokenEndpoint`                 | Oauth Token URL                                                                                            | `"https://ddn-oauth.pro.hasura.io/oauth2/token"`                         |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the ndc-snowflake-jdbc pod                                | `[]`                                |
-| `extraContainers`                                 | Optionally specify extra list of additional containers for the ndc-snowflake-jdbc pod                             | `[]`                                |
 | `resources`                                       | Resource requests and limits of ndc-snowflake-jdbc container                                                      | `{}`                                |
 | `env`                                             | Env variable section for ndc-snowflake-jdbc                                                                       | `[]`                                |
 | `replicas`                                        | Replicas setting for pod                                                                                   | `1`                                 |

--- a/charts/ndc-snowflake-jdbc/README.md
+++ b/charts/ndc-snowflake-jdbc/README.md
@@ -65,6 +65,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.JDBC_SCHEMAS`                   | A comma-separated list of schemas to include in the metadata (Optional)                                                                         | `""`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
 | `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.OTEL_SERVICE_NAME`              | OTEL Service Name (Optional)                                                                               | `ndc-snowflake-jdbc`                  |
 
 ## Additional Parameters
 

--- a/charts/ndc-snowflake-jdbc/templates/secret.yaml
+++ b/charts/ndc-snowflake-jdbc/templates/secret.yaml
@@ -8,6 +8,3 @@ data:
   HASURA_SERVICE_TOKEN_SECRET: {{ required "Error: .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET is required!" .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET | b64enc | quote }}
   {{- end }}
   JDBC_URL: {{ required "Error: .Values.connectorEnvVars.JDBC_URL is required!" .Values.connectorEnvVars.JDBC_URL | b64enc | quote }}
-{{- if .Values.observability.enabled }}
-  otel-collector-config.yaml: {{ (tpl .Values.otel.config .) | b64enc | quote }}
-{{- end }}

--- a/charts/ndc-snowflake-jdbc/values.yaml
+++ b/charts/ndc-snowflake-jdbc/values.yaml
@@ -8,8 +8,6 @@ image:
   repository: ""
   tag: ""
   pullPolicy: Always
-  otelCollectorRepository: otel/opentelemetry-collector-contrib
-  otelCollectorTag: 0.104.0
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:
@@ -47,94 +45,6 @@ hpa:
           type: Utilization
           averageUtilization: 80  # Target 80% memory utilization per pod
 
-# Observability defaults are tuned for Hasura hosted Control Plane
-observability:
-  enabled: false
-
-# Required (when observability.enabled is set to true)
-dataPlane:
-  id: ""
-  key: ""
-
-controlPlane:
-  otlpEndpoint: https://gateway.otlp.hasura.io:443
-  oauthTokenEndpoint: https://ddn-oauth.pro.hasura.io/oauth2/token
-
-otel:
-  config: |
-    extensions:
-      oauth2client:
-        client_id: {{ required "Error: .Values.dataPlane.id is required!" .Values.dataPlane.id }}
-        client_secret: {{ required "Error: .Values.dataPlane.key is required!" .Values.dataPlane.key }}
-        token_url: {{ .Values.controlPlane.oauthTokenEndpoint }}
-        scopes: ["opentelemetry:write"]
-        endpoint_params:
-          audience: https://ddn.hasura.io
-    exporters:
-      otlp/oauth:
-        endpoint: {{ .Values.controlPlane.otlpEndpoint }}
-        auth:
-          authenticator: oauth2client
-    processors:
-      batch: {}
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    service:
-      extensions: [oauth2client]
-      pipelines:
-        logs:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        metrics:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        traces:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-
-extraVolumes: |
-  {{- if .Values.observability.enabled }}
-  - name: otel-config
-    secret:
-      secretName: {{ printf "%s-secret" (include "common.name" .) }}
-      items:
-        - key: otel-collector-config.yaml
-          path: otel-collector-config.yaml
-  {{- end }}
-
-extraContainers: |
-  {{- if .Values.observability.enabled }}
-  - name: "otel-collector"
-    command:
-      - --config=/etc/otel-collector-config.yaml
-    command:
-    image: {{ template "common.image" (dict "Values" $.Values "repository" .Values.image.otelCollectorRepository "tag" .Values.image.otelCollectorTag) }}
-    env:
-    - name: "OTEL_ENDPOINT"
-      value: "{{ .Values.controlPlane.otlpEndpoint }}"
-    volumeMounts:
-      - name: otel-config
-        mountPath: "/etc/otelcol-contrib/config.yaml"
-        subPath: otel-collector-config.yaml
-  {{- end }}
-
 resources: |
   requests:
     cpu: "500m"
@@ -148,6 +58,7 @@ connectorEnvVars:
   JDBC_URL: ""
   JDBC_SCHEMAS: ""
   configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -167,7 +78,7 @@ env: |
     value: {{ .Values.connectorEnvVars.JDBC_SCHEMAS | quote }}
   {{- end }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: http://localhost:4317
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-snowflake-jdbc/values.yaml
+++ b/charts/ndc-snowflake-jdbc/values.yaml
@@ -59,6 +59,7 @@ connectorEnvVars:
   JDBC_SCHEMAS: ""
   configDirectory: ""
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  OTEL_SERVICE_NAME: ""
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -79,6 +80,13 @@ env: |
   {{- end }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-snowflake/Chart.yaml
+++ b/charts/ndc-snowflake/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.04.03
+version: v2025.04.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-snowflake/README.md
+++ b/charts/ndc-snowflake/README.md
@@ -64,7 +64,10 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.JDBC_URL`                       | The JDBC URL to connect to the database (Required)                                                                         | `""`                                 |
 | `connectorEnvVars.JDBC_SCHEMAS`                   | A comma-separated list of schemas to include in the metadata (Optional)                                                                         | `""`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
-| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`                   | Sets the OTLP endpoint to send telemetry data (traces) (Optional)                                                                         | `"http://dp-otel-collector:4317"`                                 |
+| `connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`                   | Sets the OTLP endpoint to send telemetry data (metrics)(Optional)                                                                         | `"http://dp-otel-collector:4317"`                                 |
+| `connectorEnvVars.QUARKUS_OTEL_SERVICE_NAME`           | Sets OTEL Service Name (Optional)                                                                         | `"ndc-snowflake"`                                 |
+| `connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING`                   | Enable or disable tracing for JDBC connections (Optional)                                                                         | `true`                                 |
 
 ## Additional Parameters
 

--- a/charts/ndc-snowflake/README.md
+++ b/charts/ndc-snowflake/README.md
@@ -64,6 +64,7 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `connectorEnvVars.JDBC_URL`                       | The JDBC URL to connect to the database (Required)                                                                         | `""`                                 |
 | `connectorEnvVars.JDBC_SCHEMAS`                   | A comma-separated list of schemas to include in the metadata (Optional)                                                                         | `""`                                 |
 | `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
 
 ## Additional Parameters
 
@@ -73,15 +74,6 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `image.repository`                                | Image repository containing custom created ndc-snowflake                                                     | `""`                                |
 | `image.tag`                                       | Image tag to use for custom created ndc-snowflake                                                            | `""`                                |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                            |
-| `image.otelCollectorRepository`                   | OTEL collector image repository                                                                            | `otel/opentelemetry-collector`      |
-| `image.otelCollectorTag`                          | OTEL collector image tag                                                                                   | `0.104.0`                           |
-| `observability.enabled`                           | Deploy OTEL collector as sidecar                                                                           | `false`                          |
-| `dataPlane.id`                                    | Data Plane ID (Required when observability.enabled is set to true)                                         | `""`                         |
-| `dataPlane.key`                                   | Data Plane Key (Required when observability.enabled is set to true)                                        | `""`                         |
-| `controlPlane.otlpEndpoint`                       | OTEL endpoint under Hasura                                                                                 | `"https://gateway.otlp.hasura.io:443"`                         |
-| `controlPlane.oauthTokenEndpoint`                 | Oauth Token URL                                                                                            | `"https://ddn-oauth.pro.hasura.io/oauth2/token"`                         |
-| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the ndc-snowflake pod                                | `[]`                                |
-| `extraContainers`                                 | Optionally specify extra list of additional containers for the ndc-snowflake pod                             | `[]`                                |
 | `resources`                                       | Resource requests and limits of ndc-snowflake container                                                      | `{}`                                |
 | `env`                                             | Env variable section for ndc-snowflake                                                                       | `[]`                                |
 | `replicas`                                        | Replicas setting for pod                                                                                   | `1`                                 |

--- a/charts/ndc-snowflake/templates/secret.yaml
+++ b/charts/ndc-snowflake/templates/secret.yaml
@@ -8,6 +8,3 @@ data:
   HASURA_SERVICE_TOKEN_SECRET: {{ required "Error: .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET is required!" .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET | b64enc | quote }}
   {{- end }}
   JDBC_URL: {{ required "Error: .Values.connectorEnvVars.JDBC_URL is required!" .Values.connectorEnvVars.JDBC_URL | b64enc | quote }}
-{{- if .Values.observability.enabled }}
-  otel-collector-config.yaml: {{ (tpl .Values.otel.config .) | b64enc | quote }}
-{{- end }}

--- a/charts/ndc-snowflake/values.yaml
+++ b/charts/ndc-snowflake/values.yaml
@@ -58,7 +58,10 @@ connectorEnvVars:
   JDBC_URL: ""
   JDBC_SCHEMAS: ""
   configDirectory: ""
-  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "http://dp-otel-collector:4317"
+  QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "http://dp-otel-collector:4317"
+  QUARKUS_OTEL_SERVICE_NAME: ""
+  QUARKUS_DATASOURCE_JDBC_TRACING: true
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -77,8 +80,25 @@ env: |
   - name: JDBC_SCHEMAS
     value: {{ .Values.connectorEnvVars.JDBC_SCHEMAS | quote }}
   {{- end }}
-  - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}
+  - name: QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+    value: {{ .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT }}
+  - name: QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT
+    value: {{ .Values.connectorEnvVars.QUARKUS_OTEL_EXPORTER_OTLP_METRICS_ENDPOINT }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.QUARKUS_OTEL_SERVICE_NAME }}
+  - name: QUARKUS_OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.QUARKUS_OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: QUARKUS_OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING }}
+  - name: QUARKUS_DATASOURCE_JDBC_TRACING
+    value: {{ .Values.connectorEnvVars.QUARKUS_DATASOURCE_JDBC_TRACING | quote }}
+  {{- end }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}

--- a/charts/ndc-snowflake/values.yaml
+++ b/charts/ndc-snowflake/values.yaml
@@ -8,8 +8,6 @@ image:
   repository: ""
   tag: ""
   pullPolicy: Always
-  otelCollectorRepository: otel/opentelemetry-collector-contrib
-  otelCollectorTag: 0.104.0
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:
@@ -47,94 +45,6 @@ hpa:
           type: Utilization
           averageUtilization: 80  # Target 80% memory utilization per pod
 
-# Observability defaults are tuned for Hasura hosted Control Plane
-observability:
-  enabled: false
-
-# Required (when observability.enabled is set to true)
-dataPlane:
-  id: ""
-  key: ""
-
-controlPlane:
-  otlpEndpoint: https://gateway.otlp.hasura.io:443
-  oauthTokenEndpoint: https://ddn-oauth.pro.hasura.io/oauth2/token
-
-otel:
-  config: |
-    extensions:
-      oauth2client:
-        client_id: {{ required "Error: .Values.dataPlane.id is required!" .Values.dataPlane.id }}
-        client_secret: {{ required "Error: .Values.dataPlane.key is required!" .Values.dataPlane.key }}
-        token_url: {{ .Values.controlPlane.oauthTokenEndpoint }}
-        scopes: ["opentelemetry:write"]
-        endpoint_params:
-          audience: https://ddn.hasura.io
-    exporters:
-      otlp/oauth:
-        endpoint: {{ .Values.controlPlane.otlpEndpoint }}
-        auth:
-          authenticator: oauth2client
-    processors:
-      batch: {}
-    receivers:
-      otlp:
-        protocols:
-          grpc:
-            endpoint: 0.0.0.0:4317
-          http:
-            endpoint: 0.0.0.0:4318
-    service:
-      extensions: [oauth2client]
-      pipelines:
-        logs:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        metrics:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-        traces:
-          exporters:
-            - otlp/oauth
-          processors:
-            - batch
-          receivers:
-            - otlp
-
-extraVolumes: |
-  {{- if .Values.observability.enabled }}
-  - name: otel-config
-    secret:
-      secretName: {{ printf "%s-secret" (include "common.name" .) }}
-      items:
-        - key: otel-collector-config.yaml
-          path: otel-collector-config.yaml
-  {{- end }}
-
-extraContainers: |
-  {{- if .Values.observability.enabled }}
-  - name: "otel-collector"
-    command:
-      - --config=/etc/otel-collector-config.yaml
-    command:
-    image: {{ template "common.image" (dict "Values" $.Values "repository" .Values.image.otelCollectorRepository "tag" .Values.image.otelCollectorTag) }}
-    env:
-    - name: "OTEL_ENDPOINT"
-      value: "{{ .Values.controlPlane.otlpEndpoint }}"
-    volumeMounts:
-      - name: otel-config
-        mountPath: "/etc/otelcol-contrib/config.yaml"
-        subPath: otel-collector-config.yaml
-  {{- end }}
-
 resources: |
   requests:
     cpu: "500m"
@@ -148,6 +58,7 @@ connectorEnvVars:
   JDBC_URL: ""
   JDBC_SCHEMAS: ""
   configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
 
 env: |
   {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
@@ -167,7 +78,7 @@ env: |
     value: {{ .Values.connectorEnvVars.JDBC_SCHEMAS | quote }}
   {{- end }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
-    value: http://localhost:4317
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}


### PR DESCRIPTION
- Remove init container related to observability from all connectors
- Remove flag for turning on and off observability.  This will always be enabled now
- By default, point OTLP endpoint to `http://dp-otel-collector:4317` (Which will be running in self-hosted data plane)
- Add either `OTEL_SERVICE_NAME` or `QUARKUS_OTEL_SERVICE_NAME` (Depending on type of connector).  When not specified, this defaults to chart name