### PR TITLE
ndc-nodejs-lambda: fallback to default start script

### DIFF
--- a/charts/ndc-nodejs-lambda/templates/run-script-configmap.yaml
+++ b/charts/ndc-nodejs-lambda/templates/run-script-configmap.yaml
@@ -36,5 +36,6 @@ data:
   {{- else }}
   run.sh: |
     #!/usr/bin/env bash
-    echo "git-sync is not enabled... Not executing anything within container."
+    echo "git-sync is not enabled. So falling back to use default start script."
+    /scripts/start.sh
   {{- end }}


### PR DESCRIPTION
Request arising from [here](https://hasurahq.slack.com/archives/C06HPRJCFH7/p1751940554814509).

If `gitSync` is not enabled, it results in a `CrashLoopBackOff` because it is just executing an echo command and exiting. With this change, we will try to fallback to [the default start script](https://github.com/hasura/ndc-nodejs-lambda/blob/main/Dockerfile#L19C2-L19) of the ndc-nodejs-lambda connector and succeed the run.