### PR TITLE
SA support.  Document image pull secret

### DIFF
--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -9,7 +9,7 @@ jobs:
   detect-changed-charts:
     runs-on: ubuntu-latest
     outputs:
-      charts: ${{ steps.extract.outputs.chart_names }}   # <- this must be here at job level, not step level
+      charts: ${{ steps.extract.outputs.chart_names }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -24,17 +24,16 @@ jobs:
         id: extract
         run: |
           echo "Changed files: ${{ steps.changed.outputs.all_changed_files }}"
-          mapfile -t changed_files <<< "${{ steps.changed.outputs.all_changed_files }}"
           chart_names=()
-          for file in "${changed_files[@]}"; do
+          for file in ${{ steps.changed.outputs.all_changed_files }}; do
             chart_dir=$(dirname "$file")
             chart_name=$(basename "$chart_dir")
-            chart_names+=("$chart_name")
+            chart_names+=("\"$chart_name\"")
           done
-          unique_sorted_chart_names=$(printf '%s\n' "${chart_names[@]}" | sort -u)
-          json_array=$(printf '%s\n' "${unique_sorted_chart_names[@]}" | jq -R . | jq -s .)
-          json_array_one_line=$(echo "$json_array" | jq -c .)
-          echo "chart_names=$json_array_one_line" >> "$GITHUB_OUTPUT"
+          # Create JSON array string for output
+          chart_names_json="[${chart_names[*]}]"
+          echo "chart_names=$chart_names_json" >> $GITHUB_OUTPUT
+
 
   validate-helm-charts:
     needs: detect-changed-charts
@@ -49,7 +48,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4.0.0
 
-      - name: Helm Dependency Update
+      - name: Helm dep update
         run: helm dependency update charts/${{ matrix.chart }}
 
       - name: Lint Helm Chart

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -24,14 +24,14 @@ jobs:
         id: extract
         run: |
           echo "Changed files: ${{ steps.changed.outputs.all_changed_files }}"
-          chart_names=""
+          chart_names=()
           for file in ${{ steps.changed.outputs.all_changed_files }}; do
             chart_dir=$(dirname "$file")
             chart_name=$(basename "$chart_dir")
-            chart_names="$chart_names $chart_name"
+            chart_names+=("\"$chart_name\"")
           done
-          chart_names=$(echo "$chart_names" | tr ' ' '\n' | sort -u | tr '\n' ',' | sed 's/,$//')
-          echo "chart_names=$chart_names" >> $GITHUB_OUTPUT
+          json_array="[${chart_names[*]}]"
+          echo "chart_names=${json_array}" >> $GITHUB_OUTPUT
         outputs:
           chart_names: ${{ steps.extract.outputs.chart_names }}
 
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chart: [${{ fromJson(needs.detect-changed-charts.outputs.charts) }}]
+        chart: ${{ fromJson(needs.detect-changed-charts.outputs.charts) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -9,7 +9,7 @@ jobs:
   detect-changed-charts:
     runs-on: ubuntu-latest
     outputs:
-      charts: ${{ steps.changed.outputs.chart_names }}
+      charts: ${{ steps.extract.outputs.chart_names }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -31,9 +31,7 @@ jobs:
             chart_names+=("\"$chart_name\"")
           done
           json_array="[${chart_names[*]}]"
-          echo "chart_names=${json_array}" >> $GITHUB_OUTPUT
-        outputs:
-          chart_names: ${{ steps.extract.outputs.chart_names }}
+          echo "chart_names=${json_array}" >> "$GITHUB_OUTPUT"
 
   validate-helm-charts:
     needs: detect-changed-charts
@@ -52,7 +50,6 @@ jobs:
         run: helm lint charts/${{ matrix.chart }}
 
       - name: Run Helm Template
-        shell: bash
         run: |
           chart="${{ matrix.chart }}"
           echo "Running helm template for chart: $chart"
@@ -67,5 +64,8 @@ jobs:
               helm template gateway charts/ndc-bigquery \
                 --values tests/ndc-bigquery-git-sync-values.yaml \
                 --namespace connector-ns
+              ;;
+            *)
+              echo "No specific test defined for chart: $chart"
               ;;
           esac

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -30,8 +30,12 @@ jobs:
             chart_name=$(basename "$chart_dir")
             chart_names+=("\"$chart_name\"")
           done
-          # Create JSON array string for output
-          chart_names_json="[${chart_names[*]}]"
+
+          # Join with commas, no trailing comma
+          chart_names_json="["
+          chart_names_json+=$(IFS=, ; echo "${chart_names[*]}")
+          chart_names_json+="]"
+
           echo "chart_names=$chart_names_json" >> $GITHUB_OUTPUT
 
 

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -66,13 +66,190 @@ jobs:
 
           case "$chart" in
             ndc-bigquery)
+              echo "Rendeing ndc-bigquery"
               helm template connector charts/ndc-bigquery \
                 --values tests/ndc-bigquery-values.yaml \
                 --namespace connector-ns
-              ;;
-            ndc-bigquery-git-sync)
-              helm template gateway charts/ndc-bigquery-git-sync \
+
+              echo "Rendeing ndc-bigquery-git-sync"
+              helm template connector-git-sync charts/ndc-bigquery \
                 --values tests/ndc-bigquery-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-connector-oracle)
+              echo "Rendeing ndc-connector-oracle"
+              helm template connector charts/ndc-connector-oracle \
+                --values tests/ndc-connector-oracle-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-connector-oracle-git-sync"
+              helm template connector-git-sync charts/ndc-connector-oracle \
+                --values tests/ndc-connector-oracle-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-connector-phoenix)
+              echo "Rendeing ndc-connector-phoenix"
+              helm template connector charts/ndc-connector-phoenix \
+                --values tests/ndc-connector-phoenix-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-connector-phoenix-git-sync"
+              helm template connector-git-sync charts/ndc-connector-phoenix \
+                --values tests/ndc-connector-phoenix-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-duckduckapi)
+              echo "Rendeing ndc-duckduckapi"
+              helm template connector charts/ndc-duckduckapi \
+                --values tests/ndc-duckduckapi-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-duckduckapi-git-sync"
+              helm template connector-git-sync charts/ndc-duckduckapi \
+                --values tests/ndc-duckduckapi-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-elasticsearch)
+              echo "Rendeing ndc-elasticsearch"
+              helm template connector charts/ndc-elasticsearch \
+                --values tests/ndc-elasticsearch-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-elasticsearch-git-sync"
+              helm template connector-git-sync charts/ndc-elasticsearch \
+                --values tests/ndc-elasticsearch-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-graphql)
+              echo "Rendeing ndc-graphql"
+              helm template connector charts/ndc-graphql \
+                --values tests/ndc-graphql-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-graphql-git-sync"
+              helm template connector-git-sync charts/ndc-graphql \
+                --values tests/ndc-graphql-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-http)
+              echo "Rendeing ndc-http"
+              helm template connector charts/ndc-http \
+                --values tests/ndc-http-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-http-git-sync"
+              helm template connector-git-sync charts/ndc-http \
+                --values tests/ndc-http-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-jvm-mysql)
+              echo "Rendeing ndc-jvm-mysql"
+              helm template connector charts/ndc-jvm-mysql \
+                --values tests/ndc-jvm-mysql-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-jvm-mysql-git-sync"
+              helm template connector-git-sync charts/ndc-jvm-mysql \
+                --values tests/ndc-jvm-mysql-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-jvm-trino)
+              echo "Rendeing ndc-jvm-trino"
+              helm template connector charts/ndc-jvm-trino \
+                --values tests/ndc-jvm-trino-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-jvm-trino-git-sync"
+              helm template connector-git-sync charts/ndc-jvm-trino \
+                --values tests/ndc-jvm-trino-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-mongodb)
+              echo "Rendeing ndc-mongodb"
+              helm template connector charts/ndc-mongodb \
+                --values tests/ndc-mongodb-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-mongodb-git-sync"
+              helm template connector-git-sync charts/ndc-mongodb \
+                --values tests/ndc-mongodb-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-mysql-jdbc)
+              echo "Rendeing ndc-mysql-jdbc"
+              helm template connector charts/ndc-mysql-jdbc \
+                --values tests/ndc-mysql-jdbc-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-mysql-jdbc-git-sync"
+              helm template connector-git-sync charts/ndc-mysql-jdbc \
+                --values tests/ndc-mysql-jdbc-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-nodejs-lambda)
+              echo "Rendeing ndc-nodejs-lambda"
+              helm template connector charts/ndc-nodejs-lambda \
+                --values tests/ndc-nodejs-lambda-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-nodejs-lambda-git-sync"
+              helm template connector-git-sync charts/ndc-nodejs-lambda \
+                --values tests/ndc-nodejs-lambda-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-open-api-lambda)
+              echo "Rendeing ndc-open-api-lambda"
+              helm template connector charts/ndc-open-api-lambda \
+                --values tests/ndc-open-api-lambda-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-open-api-lambda-git-sync"
+              helm template connector-git-sync charts/ndc-open-api-lambda \
+                --values tests/ndc-open-api-lambda-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-postgres)
+              echo "Rendeing ndc-postgres"
+              helm template connector charts/ndc-postgres \
+                --values tests/ndc-postgres-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-postgres-git-sync"
+              helm template connector-git-sync charts/ndc-postgres \
+                --values tests/ndc-postgres-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-postgres-jdbc)
+              echo "Rendeing ndc-postgres-jdbc"
+              helm template connector charts/ndc-postgres-jdbc \
+                --values tests/ndc-postgres-jdbc-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-postgres-jdbc-git-sync"
+              helm template connector-git-sync charts/ndc-postgres-jdbc \
+                --values tests/ndc-postgres-jdbc-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-snowflake)
+              echo "Rendeing ndc-snowflake"
+              helm template connector charts/ndc-snowflake \
+                --values tests/ndc-snowflake-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-snowflake-git-sync"
+              helm template connector-git-sync charts/ndc-snowflake \
+                --values tests/ndc-snowflake-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
+            ndc-snowflake=jdbc)
+              echo "Rendeing ndc-snowflake=jdbc"
+              helm template connector charts/ndc-snowflake=jdbc \
+                --values tests/ndc-snowflake=jdbc-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendeing ndc-snowflake=jdbc-git-sync"
+              helm template connector-git-sync charts/ndc-snowflake=jdbc \
+                --values tests/ndc-snowflake=jdbc-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
           esac

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -66,188 +66,188 @@ jobs:
 
           case "$chart" in
             ndc-bigquery)
-              echo "Rendeing ndc-bigquery"
+              echo "Rendering ndc-bigquery"
               helm template connector charts/ndc-bigquery \
                 --values tests/ndc-bigquery-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-bigquery-git-sync"
+              echo "Rendering ndc-bigquery-git-sync"
               helm template connector-git-sync charts/ndc-bigquery \
                 --values tests/ndc-bigquery-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-connector-oracle)
-              echo "Rendeing ndc-connector-oracle"
+              echo "Rendering ndc-connector-oracle"
               helm template connector charts/ndc-connector-oracle \
                 --values tests/ndc-connector-oracle-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-connector-oracle-git-sync"
+              echo "Rendering ndc-connector-oracle-git-sync"
               helm template connector-git-sync charts/ndc-connector-oracle \
                 --values tests/ndc-connector-oracle-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-connector-phoenix)
-              echo "Rendeing ndc-connector-phoenix"
+              echo "Rendering ndc-connector-phoenix"
               helm template connector charts/ndc-connector-phoenix \
                 --values tests/ndc-connector-phoenix-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-connector-phoenix-git-sync"
+              echo "Rendering ndc-connector-phoenix-git-sync"
               helm template connector-git-sync charts/ndc-connector-phoenix \
                 --values tests/ndc-connector-phoenix-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-duckduckapi)
-              echo "Rendeing ndc-duckduckapi"
+              echo "Rendering ndc-duckduckapi"
               helm template connector charts/ndc-duckduckapi \
                 --values tests/ndc-duckduckapi-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-duckduckapi-git-sync"
+              echo "Rendering ndc-duckduckapi-git-sync"
               helm template connector-git-sync charts/ndc-duckduckapi \
                 --values tests/ndc-duckduckapi-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-elasticsearch)
-              echo "Rendeing ndc-elasticsearch"
+              echo "Rendering ndc-elasticsearch"
               helm template connector charts/ndc-elasticsearch \
                 --values tests/ndc-elasticsearch-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-elasticsearch-git-sync"
+              echo "Rendering ndc-elasticsearch-git-sync"
               helm template connector-git-sync charts/ndc-elasticsearch \
                 --values tests/ndc-elasticsearch-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-graphql)
-              echo "Rendeing ndc-graphql"
+              echo "Rendering ndc-graphql"
               helm template connector charts/ndc-graphql \
                 --values tests/ndc-graphql-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-graphql-git-sync"
+              echo "Rendering ndc-graphql-git-sync"
               helm template connector-git-sync charts/ndc-graphql \
                 --values tests/ndc-graphql-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-http)
-              echo "Rendeing ndc-http"
+              echo "Rendering ndc-http"
               helm template connector charts/ndc-http \
                 --values tests/ndc-http-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-http-git-sync"
+              echo "Rendering ndc-http-git-sync"
               helm template connector-git-sync charts/ndc-http \
                 --values tests/ndc-http-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-jvm-mysql)
-              echo "Rendeing ndc-jvm-mysql"
+              echo "Rendering ndc-jvm-mysql"
               helm template connector charts/ndc-jvm-mysql \
                 --values tests/ndc-jvm-mysql-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-jvm-mysql-git-sync"
+              echo "Rendering ndc-jvm-mysql-git-sync"
               helm template connector-git-sync charts/ndc-jvm-mysql \
                 --values tests/ndc-jvm-mysql-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-jvm-trino)
-              echo "Rendeing ndc-jvm-trino"
+              echo "Rendering ndc-jvm-trino"
               helm template connector charts/ndc-jvm-trino \
                 --values tests/ndc-jvm-trino-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-jvm-trino-git-sync"
+              echo "Rendering ndc-jvm-trino-git-sync"
               helm template connector-git-sync charts/ndc-jvm-trino \
                 --values tests/ndc-jvm-trino-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-mongodb)
-              echo "Rendeing ndc-mongodb"
+              echo "Rendering ndc-mongodb"
               helm template connector charts/ndc-mongodb \
                 --values tests/ndc-mongodb-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-mongodb-git-sync"
+              echo "Rendering ndc-mongodb-git-sync"
               helm template connector-git-sync charts/ndc-mongodb \
                 --values tests/ndc-mongodb-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-mysql-jdbc)
-              echo "Rendeing ndc-mysql-jdbc"
+              echo "Rendering ndc-mysql-jdbc"
               helm template connector charts/ndc-mysql-jdbc \
                 --values tests/ndc-mysql-jdbc-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-mysql-jdbc-git-sync"
+              echo "Rendering ndc-mysql-jdbc-git-sync"
               helm template connector-git-sync charts/ndc-mysql-jdbc \
                 --values tests/ndc-mysql-jdbc-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-nodejs-lambda)
-              echo "Rendeing ndc-nodejs-lambda"
+              echo "Rendering ndc-nodejs-lambda"
               helm template connector charts/ndc-nodejs-lambda \
                 --values tests/ndc-nodejs-lambda-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-nodejs-lambda-git-sync"
+              echo "Rendering ndc-nodejs-lambda-git-sync"
               helm template connector-git-sync charts/ndc-nodejs-lambda \
                 --values tests/ndc-nodejs-lambda-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-open-api-lambda)
-              echo "Rendeing ndc-open-api-lambda"
+              echo "Rendering ndc-open-api-lambda"
               helm template connector charts/ndc-open-api-lambda \
                 --values tests/ndc-open-api-lambda-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-open-api-lambda-git-sync"
+              echo "Rendering ndc-open-api-lambda-git-sync"
               helm template connector-git-sync charts/ndc-open-api-lambda \
                 --values tests/ndc-open-api-lambda-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-postgres)
-              echo "Rendeing ndc-postgres"
+              echo "Rendering ndc-postgres"
               helm template connector charts/ndc-postgres \
                 --values tests/ndc-postgres-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-postgres-git-sync"
+              echo "Rendering ndc-postgres-git-sync"
               helm template connector-git-sync charts/ndc-postgres \
                 --values tests/ndc-postgres-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-postgres-jdbc)
-              echo "Rendeing ndc-postgres-jdbc"
+              echo "Rendering ndc-postgres-jdbc"
               helm template connector charts/ndc-postgres-jdbc \
                 --values tests/ndc-postgres-jdbc-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-postgres-jdbc-git-sync"
+              echo "Rendering ndc-postgres-jdbc-git-sync"
               helm template connector-git-sync charts/ndc-postgres-jdbc \
                 --values tests/ndc-postgres-jdbc-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-snowflake)
-              echo "Rendeing ndc-snowflake"
+              echo "Rendering ndc-snowflake"
               helm template connector charts/ndc-snowflake \
                 --values tests/ndc-snowflake-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-snowflake-git-sync"
+              echo "Rendering ndc-snowflake-git-sync"
               helm template connector-git-sync charts/ndc-snowflake \
                 --values tests/ndc-snowflake-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             ndc-snowflake=jdbc)
-              echo "Rendeing ndc-snowflake=jdbc"
+              echo "Rendering ndc-snowflake=jdbc"
               helm template connector charts/ndc-snowflake=jdbc \
                 --values tests/ndc-snowflake=jdbc-values.yaml \
                 --namespace connector-ns
 
-              echo "Rendeing ndc-snowflake=jdbc-git-sync"
+              echo "Rendering ndc-snowflake=jdbc-git-sync"
               helm template connector-git-sync charts/ndc-snowflake=jdbc \
                 --values tests/ndc-snowflake=jdbc-git-sync-values.yaml \
                 --namespace connector-ns

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -9,7 +9,7 @@ jobs:
   detect-changed-charts:
     runs-on: ubuntu-latest
     outputs:
-      charts: ${{ steps.extract.outputs.chart_names }}
+      charts: ${{ steps.extract.outputs.chart_names }}   # <- this must be here at job level, not step level
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -24,7 +24,6 @@ jobs:
         id: extract
         run: |
           echo "Changed files: ${{ steps.changed.outputs.all_changed_files }}"
-          # Read changed files into an array
           mapfile -t changed_files <<< "${{ steps.changed.outputs.all_changed_files }}"
           chart_names=()
           for file in "${changed_files[@]}"; do
@@ -32,15 +31,10 @@ jobs:
             chart_name=$(basename "$chart_dir")
             chart_names+=("$chart_name")
           done
-          # Deduplicate and sort
           unique_sorted_chart_names=$(printf '%s\n' "${chart_names[@]}" | sort -u)
-          # Convert to JSON array
           json_array=$(printf '%s\n' "${unique_sorted_chart_names[@]}" | jq -R . | jq -s .)
-          # Compress to one line for GitHub Actions output
           json_array_one_line=$(echo "$json_array" | jq -c .)
           echo "chart_names=$json_array_one_line" >> "$GITHUB_OUTPUT"
-        outputs:
-          chart_names: ${{ steps.extract.outputs.chart_names }}
 
   validate-helm-charts:
     needs: detect-changed-charts

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -24,16 +24,23 @@ jobs:
         id: extract
         run: |
           echo "Changed files: ${{ steps.changed.outputs.all_changed_files }}"
+          # Read changed files into an array
+          mapfile -t changed_files <<< "${{ steps.changed.outputs.all_changed_files }}"
           chart_names=()
-          for file in ${{ steps.changed.outputs.all_changed_files }}; do
+          for file in "${changed_files[@]}"; do
             chart_dir=$(dirname "$file")
             chart_name=$(basename "$chart_dir")
             chart_names+=("$chart_name")
           done
-
-          # Turn into JSON array string
-          json_array=$(printf '%s\n' "${chart_names[@]}" | jq -R . | jq -s .)
-          echo "chart_names=${json_array}" >> "$GITHUB_OUTPUT"
+          # Deduplicate and sort
+          unique_sorted_chart_names=$(printf '%s\n' "${chart_names[@]}" | sort -u)
+          # Convert to JSON array
+          json_array=$(printf '%s\n' "${unique_sorted_chart_names[@]}" | jq -R . | jq -s .)
+          # Compress to one line for GitHub Actions output
+          json_array_one_line=$(echo "$json_array" | jq -c .)
+          echo "chart_names=$json_array_one_line" >> "$GITHUB_OUTPUT"
+        outputs:
+          chart_names: ${{ steps.extract.outputs.chart_names }}
 
   validate-helm-charts:
     needs: detect-changed-charts
@@ -52,6 +59,7 @@ jobs:
         run: helm lint charts/${{ matrix.chart }}
 
       - name: Run Helm Template
+        shell: bash
         run: |
           chart="${{ matrix.chart }}"
           echo "Running helm template for chart: $chart"
@@ -63,11 +71,12 @@ jobs:
                 --namespace connector-ns
               ;;
             ndc-bigquery-git-sync)
-              helm template gateway charts/ndc-bigquery \
+              helm template gateway charts/ndc-bigquery-git-sync \
                 --values tests/ndc-bigquery-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
             *)
-              echo "No specific test defined for chart: $chart"
+              # Default template run for other charts
+              helm template "$chart" charts/"$chart"
               ;;
           esac

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -49,6 +49,9 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4.0.0
 
+      - name: Helm Dependency Update
+        run: helm dependency update charts/${{ matrix.chart }}
+
       - name: Lint Helm Chart
         run: helm lint charts/${{ matrix.chart }}
 
@@ -68,9 +71,5 @@ jobs:
               helm template gateway charts/ndc-bigquery-git-sync \
                 --values tests/ndc-bigquery-git-sync-values.yaml \
                 --namespace connector-ns
-              ;;
-            *)
-              # Default template run for other charts
-              helm template "$chart" charts/"$chart"
               ;;
           esac

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -28,9 +28,11 @@ jobs:
           for file in ${{ steps.changed.outputs.all_changed_files }}; do
             chart_dir=$(dirname "$file")
             chart_name=$(basename "$chart_dir")
-            chart_names+=("\"$chart_name\"")
+            chart_names+=("$chart_name")
           done
-          json_array="[${chart_names[*]}]"
+
+          # Turn into JSON array string
+          json_array=$(printf '%s\n' "${chart_names[@]}" | jq -R . | jq -s .)
           echo "chart_names=${json_array}" >> "$GITHUB_OUTPUT"
 
   validate-helm-charts:

--- a/CONNECTORS
+++ b/CONNECTORS
@@ -4,6 +4,7 @@ ndc-connector-phoenix
 ndc-duckduckapi
 ndc-elasticsearch
 ndc-graphql
+ndc-http
 ndc-jvm-mysql
 ndc-jvm-trino
 ndc-mongodb

--- a/charts/ndc-bigquery/Chart.yaml
+++ b/charts/ndc-bigquery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.06.10
+version: v2025.07.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-bigquery/Chart.yaml
+++ b/charts/ndc-bigquery/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-bigquery/Chart.yaml
+++ b/charts/ndc-bigquery/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.30
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-bigquery/README.md
+++ b/charts/ndc-bigquery/README.md
@@ -71,9 +71,11 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -101,6 +103,20 @@ secrets:
         email: "support@hasura.io"
 ```
 
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -123,6 +139,12 @@ secrets:
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-bigquery                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-bigquery                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |

--- a/charts/ndc-bigquery/README.md
+++ b/charts/ndc-bigquery/README.md
@@ -71,6 +71,36 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -113,3 +143,5 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `initContainers.gitSync.repo`                     | Git repository to read from (Used when initContainers.gitSync.enabled is set to true)                      | `git@github.com:<org>/<repo>`       |
 | `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
 | `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-bigquery/values.yaml
+++ b/charts/ndc-bigquery/values.yaml
@@ -23,6 +23,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+serviceAccount:
+  enabled: false
+  name: ""
+
 initContainers:
   gitSync:
     enabled: false

--- a/charts/ndc-connector-oracle/Chart.yaml
+++ b/charts/ndc-connector-oracle/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.06.10
+version: v2025.07.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-connector-oracle/Chart.yaml
+++ b/charts/ndc-connector-oracle/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-connector-oracle/Chart.yaml
+++ b/charts/ndc-connector-oracle/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.30
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-connector-oracle/README.md
+++ b/charts/ndc-connector-oracle/README.md
@@ -65,9 +65,11 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -95,6 +97,20 @@ secrets:
         email: "support@hasura.io"
 ```
 
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -118,6 +134,12 @@ secrets:
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-connector-oracle                                                     | `""`                                |
 | `image.tag`                                       | Image tag to use for custom created ndc-connector-oracle                                                            | `""`                                |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                            |

--- a/charts/ndc-connector-oracle/README.md
+++ b/charts/ndc-connector-oracle/README.md
@@ -65,6 +65,36 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -108,3 +138,5 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `initContainers.gitSync.repo`                     | Git repository to read from (Used when initContainers.gitSync.enabled is set to true)                      | `git@github.com:<org>/<repo>`       |
 | `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
 | `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-connector-oracle/values.yaml
+++ b/charts/ndc-connector-oracle/values.yaml
@@ -23,6 +23,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+serviceAccount:
+  enabled: false
+  name: ""
+
 initContainers:
   gitSync:
     enabled: false

--- a/charts/ndc-connector-phoenix/Chart.yaml
+++ b/charts/ndc-connector-phoenix/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-connector-phoenix/Chart.yaml
+++ b/charts/ndc-connector-phoenix/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.06.10
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-connector-phoenix/README.md
+++ b/charts/ndc-connector-phoenix/README.md
@@ -64,9 +64,11 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -94,6 +96,20 @@ secrets:
         email: "support@hasura.io"
 ```
 
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -116,6 +132,12 @@ secrets:
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-connector-phoenix                                                    | `""`                                |
 | `image.tag`                                       | Image tag to use for custom created ndc-connector-phoenix                                                           | `""`                                |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                            |

--- a/charts/ndc-connector-phoenix/README.md
+++ b/charts/ndc-connector-phoenix/README.md
@@ -64,6 +64,36 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -106,3 +136,5 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `initContainers.gitSync.repo`                     | Git repository to read from (Used when initContainers.gitSync.enabled is set to true)                      | `git@github.com:<org>/<repo>`       |
 | `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
 | `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-connector-phoenix/values.yaml
+++ b/charts/ndc-connector-phoenix/values.yaml
@@ -23,6 +23,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+serviceAccount:
+  enabled: false
+  name: ""
+
 initContainers:
   gitSync:
     enabled: false

--- a/charts/ndc-duckduckapi/Chart.yaml
+++ b/charts/ndc-duckduckapi/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.06.12
+version: v2025.07.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-duckduckapi/Chart.yaml
+++ b/charts/ndc-duckduckapi/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-duckduckapi/Chart.yaml
+++ b/charts/ndc-duckduckapi/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.30
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-duckduckapi/README.md
+++ b/charts/ndc-duckduckapi/README.md
@@ -71,9 +71,11 @@ If you prefer **not to commit** the `node_modules` directory to your repository,
 - Install your Helm chart with `--set initContainers.gitSync.depsPackaged=false`
   - This tells the system to use the pre-packaged dependencies instead of expecting them in the Git repo.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -99,6 +101,20 @@ secrets:
         password: |
           {}
         email: "support@hasura.io"
+```
+
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
 ```
 
 ## Connector ENV Inputs
@@ -133,6 +149,12 @@ You can pass custom environment variables to the connector container by defining
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-duckduckapi                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-duckduckapi                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |

--- a/charts/ndc-duckduckapi/README.md
+++ b/charts/ndc-duckduckapi/README.md
@@ -71,6 +71,36 @@ If you prefer **not to commit** the `node_modules` directory to your repository,
 - Install your Helm chart with `--set initContainers.gitSync.depsPackaged=false`
   - This tells the system to use the pre-packaged dependencies instead of expecting them in the Git repo.
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -124,3 +154,5 @@ You can pass custom environment variables to the connector container by defining
 | `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
 | `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
 | `initContainers.gitSync.depsPackaged`             | Whether node_modules was packaged into git repo (Used when initContainers.gitSync.enabled is set to true)  | `true`                              |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-duckduckapi/values.yaml
+++ b/charts/ndc-duckduckapi/values.yaml
@@ -23,6 +23,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+serviceAccount:
+  enabled: false
+  name: ""
+
 initContainers:
   gitSync:
     enabled: false

--- a/charts/ndc-elasticsearch/Chart.yaml
+++ b/charts/ndc-elasticsearch/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-elasticsearch/Chart.yaml
+++ b/charts/ndc-elasticsearch/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.06.10
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-elasticsearch/README.md
+++ b/charts/ndc-elasticsearch/README.md
@@ -133,6 +133,36 @@ helm upgrade --install <release-name> \
   hasura-ddn/ndc-elasticsearch
 ```
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |

--- a/charts/ndc-elasticsearch/README.md
+++ b/charts/ndc-elasticsearch/README.md
@@ -133,9 +133,11 @@ helm upgrade --install <release-name> \
   hasura-ddn/ndc-elasticsearch
 ```
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -161,6 +163,20 @@ secrets:
         password: |
           {}
         email: "support@hasura.io"
+```
+
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
 ```
 
 ## Connector ENV Inputs
@@ -205,6 +221,12 @@ secrets:
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-elasticsearch                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-elasticsearch                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |

--- a/charts/ndc-graphql/Chart.yaml
+++ b/charts/ndc-graphql/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.06.10
+version: v2025.07.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-graphql/Chart.yaml
+++ b/charts/ndc-graphql/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-graphql/Chart.yaml
+++ b/charts/ndc-graphql/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.30
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-graphql/README.md
+++ b/charts/ndc-graphql/README.md
@@ -65,6 +65,36 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -105,3 +135,5 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `initContainers.gitSync.repo`                     | Git repository to read from (Used when initContainers.gitSync.enabled is set to true)                      | `git@github.com:<org>/<repo>`       |
 | `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
 | `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-graphql/README.md
+++ b/charts/ndc-graphql/README.md
@@ -65,9 +65,11 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -95,6 +97,20 @@ secrets:
         email: "support@hasura.io"
 ```
 
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -115,6 +131,12 @@ secrets:
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-graphql                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-graphql                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |

--- a/charts/ndc-graphql/values.yaml
+++ b/charts/ndc-graphql/values.yaml
@@ -23,6 +23,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+serviceAccount:
+  enabled: false
+  name: ""
+
 initContainers:
   gitSync:
     enabled: false

--- a/charts/ndc-http/Chart.yaml
+++ b/charts/ndc-http/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-http/Chart.yaml
+++ b/charts/ndc-http/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.30
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-http/Chart.yaml
+++ b/charts/ndc-http/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: ndc-http
+description: (DDN) A Helm chart for deploying ndc-http
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: v2025.07.30
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "3.0.0"
+
+dependencies:
+- name: common
+  version: 0.0.13
+  repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-http/README.md
+++ b/charts/ndc-http/README.md
@@ -1,0 +1,139 @@
+# Ndc-http Helm Chart
+
+This chart deploys the ndc-http connector. Refer to the pre-requisites section [here](../../README.md#get-started)
+
+## Connector Image
+
+If you're running `docker compose build` within your Supergraph to build a custom connector image, or if you're using
+the **git-sync** option with a Hasura-provided connector image, the base image used in both cases is: `ghcr.io/hasura/ndc-http`
+
+To determine the specific version of the image being used, check the `connector-metadata.yaml` file located under your Supergraph at: `app/connector/<connector-name>/.hasura-connector/connector-metadata.yaml`
+
+## Install Chart
+
+See all [configuration](#parameters) below.
+
+```bash
+# EXAMPLES:
+
+# helm template and apply manifests via kubectl (example)
+helm template <release-name> \
+  --set namespace="default" \
+  --set image.repository="my_repo/ndc-http" \
+  --set image.tag="my_custom_image_tag" \
+  --set connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET="token" \
+  hasura-ddn/ndc-http | kubectl apply -f-
+
+# helm upgrade --install (pass configuration via command line)
+helm upgrade --install <release-name> \
+  --set namespace="default" \
+  --set image.repository="my_repo/ndc-http" \
+  --set image.tag="my_custom_image_tag" \
+  --set connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET="token" \
+  hasura-ddn/ndc-http
+```
+
+## Enabling git-sync
+
+Follow the pre-requisite [here](../../README.md#using-git-for-metadata-files) which has to be done once and deployed on the cluster.
+
+Replace `<git_domain>`, `<org>` and `<repo>` placeholders in the below command to suit your git repository.
+
+Additionally, ensure that `connectorEnvVars.configDirectory` is set to the correct path using the format shown below. Replace `<repo>` with the name of your Git repository, and `<connector-name>` with the name of your connector (found under `app/connector` in your Supergraph repo).  Ensure that you are not adding the `.git` suffix to `<repo>`.
+
+Example: If your repo is `my-repo` and your connector is `my-connector`, the path should be:  `/work-dir/my-repo/app/connector/my-connector`
+
+- Note: For `https` based checkout, a typical URL format for `initContainers.gitSync.repo` will be `https://<git_domain>/<org>/<repo>`.  For `ssh` based checkout, a typical URL format will be `git@<git_domain>:<org>/<repo>`
+
+```bash
+helm upgrade --install <release-name> \
+  --set namespace="default" \
+  --set image.repository="my_repo/ndc-http" \
+  --set image.tag="my_custom_image_tag" \
+  --set connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET="token" \
+  --set initContainers.gitSync.enabled="true" \
+  --set initContainers.gitSync.repo="git@<git_domain>:<org>/<repo>" \
+  --set initContainers.gitSync.branch="main" \
+  --set connectorEnvVars.configDirectory="/work-dir/<repo>/app/connector/<connector-name>" \
+  hasura-ddn/ndc-http
+```
+
+## Committing code to git
+
+When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
+
+## Adjustments to config.yaml
+
+Before introspecting, ensure that you make necessary changes to `config.yaml`.  See [this](https://github.com/hasura/ndc-http/blob/main/docs/configuration.md) for more information.
+
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
+## Connector ENV Inputs
+
+| Name                                              | Description                                                                                                | Value                           |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET`    | Hasura Service Token Secret.  This value comes from your Supergraph’s `.env` file and corresponds to the connector's `HASURA_SERVICE_TOKEN_SECRET` environment variable. (Optional)                                                                     | `""`                            |
+| `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.OTEL_SERVICE_NAME`              | OTEL Service Name (Optional)                                                                               | `ndc-http`                  |
+
+## Additional Parameters
+
+| Name                                              | Description                                                                                                | Value                           |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `namespace`                                       | Namespace to deploy to                                                                                     | `"default"`                     |
+| `additionalAnnotations.checksum/config`           | Adds a checksum annotation for the `secret.yaml` file to force rollout on changes                          | `{{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}`                     |
+| `additionalAnnotations.app.kubernetes.io/access-group` | Labels resources with an access group for organizational or access control purposes                   | `connector`                     |
+| `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
+| `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
+| `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `image.repository`                                | Image repository containing custom created ndc-http                                                    | `""`                            |
+| `image.tag`                                       | Image tag to use for custom created ndc-http                                                           | `""`                            |
+| `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |
+| `resources`                                       | Resource requests and limits of ndc-http container                                                     | `{}`                            |
+| `env`                                             | Env variable section for ndc-http                                                                      | `[]`                            |
+| `replicas`                                        | Replicas setting for pod                                                                                   | `1`                             |
+| `wsInactiveExpiryMins`                            | To be documented                                                                                           | `1`                             |
+| `securityContext`                                 | Define privilege and access control settings for a Pod or Container                                        | `{}`                            |
+| `healthChecks.enabled`                            | Enable health check for ndc-http container                                                             | `false`                         |
+| `healthChecks.livenessProbePath`                  | Health check liveness Probe path ndc-http container                                                    | `"/healthz"`                    |
+| `healthChecks.readinessProbePath`                 | Health check readiness Probe path ndc-http container                                                   | `"/healthz"`                    |
+| `hpa.enabled`                                     | Enable HPA for ndc-http.  Ensure metrics cluster is configured when enabling                           | `false`                         |
+| `hpa.minReplicas`                                 | minReplicas setting for HPA                                                                                | `2`                             |
+| `hpa.maxReplicas`                                 | maxReplicas setting for HPA                                                                                | `4`                             |
+| `hpa.metrics.resource.name`                       | Resource name to autoscale on                                                                              | ``                              |
+| `hpa.metrics.resource.target.averageUtilization`  | Utilization target on specific resource type                                                               | ``                              |
+| `initContainers.gitSync.enabled`                  | Enable reading connector config files from a git repository                                                | `false`                             |
+| `initContainers.gitSync.repo`                     | Git repository to read from (Used when initContainers.gitSync.enabled is set to true)                      | `git@github.com:<org>/<repo>`       |
+| `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
+| `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-http/README.md
+++ b/charts/ndc-http/README.md
@@ -66,9 +66,11 @@ When you enable git-sync, the code will be fetched from the repository specified
 
 Before introspecting, ensure that you make necessary changes to `config.yaml`.  See [this](https://github.com/hasura/ndc-http/blob/main/docs/configuration.md) for more information.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -96,6 +98,20 @@ secrets:
         email: "support@hasura.io"
 ```
 
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -115,6 +131,12 @@ secrets:
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-http                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-http                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |

--- a/charts/ndc-http/templates/NOTES.txt
+++ b/charts/ndc-http/templates/NOTES.txt
@@ -1,0 +1,22 @@
+Ndc-http Helm Chart Deployment
+
+1. Deployment Information:
+   - Release Name: {{ .Release.Name }}
+   - Namespace: {{ template "common.namespace" . }}
+   - Chart Name: {{ .Chart.Name }}
+   - Chart Version: {{ .Chart.Version }}
+
+2. Service Information:
+   - Service Name: {{ template "common.name" . }}
+   - Service Port: {{ .Values.httpPort }}
+
+3. Useful Commands:
+   - Check the Deployment Status:
+     helm status {{ .Release.Name }}
+
+   - Get Detailed Information about the Deployment:
+     helm get all {{ .Release.Name }}
+
+4. Clean Up:
+   - To uninstall/delete the deployment, run:
+     helm uninstall {{ .Release.Name }}

--- a/charts/ndc-http/templates/deployment.yaml
+++ b/charts/ndc-http/templates/deployment.yaml
@@ -1,0 +1,2 @@
+# deployment.yaml
+{{- template "common.deployment" . -}}

--- a/charts/ndc-http/templates/hpa.yaml
+++ b/charts/ndc-http/templates/hpa.yaml
@@ -1,0 +1,2 @@
+# hpa.yaml
+{{- template "common.hpa" . -}}

--- a/charts/ndc-http/templates/imagepullsecret.yaml
+++ b/charts/ndc-http/templates/imagepullsecret.yaml
@@ -1,0 +1,16 @@
+{{- if ((.Values.global).dataPlane).deployImagePullSecret -}}
+{{- with .Values.secrets }}
+{{- if .imagePullSecret -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hasura-image-pull
+  namespace: {{ template "common.namespace" $ }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: |
+{{- toJson .imagePullSecret | b64enc | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/ndc-http/templates/networkPolicy.yaml
+++ b/charts/ndc-http/templates/networkPolicy.yaml
@@ -1,0 +1,2 @@
+# networkPolicy.yaml
+{{- template "common.networkPolicy" . -}}

--- a/charts/ndc-http/templates/secret.yaml
+++ b/charts/ndc-http/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-secret" (include "common.name" .) }}
+  namespace: {{ template "common.namespace" $ }}
+data:
+  {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
+  HASURA_SERVICE_TOKEN_SECRET: {{ required "Error: .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET is required!" .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET | b64enc | quote }}
+  {{- end }}

--- a/charts/ndc-http/templates/service.yaml
+++ b/charts/ndc-http/templates/service.yaml
@@ -1,0 +1,2 @@
+# service.yaml
+{{- template "common.service" . -}}

--- a/charts/ndc-http/templates/serviceaccount.yaml
+++ b/charts/ndc-http/templates/serviceaccount.yaml
@@ -1,0 +1,2 @@
+# serviceaccount.yaml
+{{- template "common.serviceaccount" . -}}

--- a/charts/ndc-http/values.yaml
+++ b/charts/ndc-http/values.yaml
@@ -1,0 +1,88 @@
+useReleaseName: true
+
+additionalAnnotations: |
+  checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+  app.kubernetes.io/access-group: connector
+
+networkPolicy:
+  ingress:
+    enabled: true
+    allowedApps:
+      - v3-engine
+
+# Container Configs
+image:
+  repository: ""
+  tag: ""
+  pullPolicy: IfNotPresent
+replicas: "1"
+wsInactiveExpiryMins: "1"
+securityContext:
+  runAsNonRoot: true
+  runAsGroup: 1000
+  runAsUser: 1000
+  fsGroup: 1000
+
+serviceAccount:
+  enabled: false
+  name: ""
+
+initContainers:
+  gitSync:
+    enabled: false
+    repo: "git@github.com:<org>/<repo>"
+    branch: "main"
+    secretName: ""
+
+healthChecks:
+  enabled: false
+  livenessProbePath: "/healthz"
+  readinessProbePath: "/healthz"
+
+hpa:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 4
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50  # Target 50% CPU utilization per pod
+
+resources: |
+  requests:
+    cpu: "500m"
+    memory: "500Mi"
+  limits:
+    cpu: "1"
+    memory: "1Gi"
+
+connectorEnvVars:
+  HASURA_SERVICE_TOKEN_SECRET: ""
+  configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  OTEL_SERVICE_NAME: ""
+
+env: |
+  {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
+  - name: HASURA_SERVICE_TOKEN_SECRET
+    valueFrom:
+      secretKeyRef:
+        key: HASURA_SERVICE_TOKEN_SECRET
+        name: {{ printf "%s-secret" (include "common.name" .) }}
+  {{- end }}
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.configDirectory }}
+  - name: HASURA_CONFIGURATION_DIRECTORY
+    value: {{ .Values.connectorEnvVars.configDirectory }}
+  {{- end }}

--- a/charts/ndc-jvm-mysql/Chart.yaml
+++ b/charts/ndc-jvm-mysql/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.06.10
+version: v2025.07.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-jvm-mysql/Chart.yaml
+++ b/charts/ndc-jvm-mysql/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-jvm-mysql/Chart.yaml
+++ b/charts/ndc-jvm-mysql/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.30
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-jvm-mysql/README.md
+++ b/charts/ndc-jvm-mysql/README.md
@@ -65,6 +65,36 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -108,3 +138,5 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `initContainers.gitSync.repo`                     | Git repository to read from (Used when initContainers.gitSync.enabled is set to true)                      | `git@github.com:<org>/<repo>`       |
 | `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
 | `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-jvm-mysql/README.md
+++ b/charts/ndc-jvm-mysql/README.md
@@ -65,9 +65,11 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -95,6 +97,20 @@ secrets:
         email: "support@hasura.io"
 ```
 
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -118,6 +134,12 @@ secrets:
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-jvm-mysql                                                    | `""`                                |
 | `image.tag`                                       | Image tag to use for custom created ndc-jvm-mysql                                                           | `""`                                |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                            |

--- a/charts/ndc-jvm-mysql/values.yaml
+++ b/charts/ndc-jvm-mysql/values.yaml
@@ -23,6 +23,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+serviceAccount:
+  enabled: false
+  name: ""
+
 initContainers:
   gitSync:
     enabled: false

--- a/charts/ndc-jvm-trino/Chart.yaml
+++ b/charts/ndc-jvm-trino/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.06.10
+version: v2025.07.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-jvm-trino/Chart.yaml
+++ b/charts/ndc-jvm-trino/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-jvm-trino/Chart.yaml
+++ b/charts/ndc-jvm-trino/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.30
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-jvm-trino/README.md
+++ b/charts/ndc-jvm-trino/README.md
@@ -65,6 +65,36 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -107,3 +137,5 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `initContainers.gitSync.repo`                     | Git repository to read from (Used when initContainers.gitSync.enabled is set to true)                      | `git@github.com:<org>/<repo>`       |
 | `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
 | `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-jvm-trino/README.md
+++ b/charts/ndc-jvm-trino/README.md
@@ -65,9 +65,11 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -95,6 +97,20 @@ secrets:
         email: "support@hasura.io"
 ```
 
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -117,6 +133,12 @@ secrets:
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-jvm-trino                                                    | `""`                                |
 | `image.tag`                                       | Image tag to use for custom created ndc-jvm-trino                                                           | `""`                                |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                            |

--- a/charts/ndc-jvm-trino/values.yaml
+++ b/charts/ndc-jvm-trino/values.yaml
@@ -23,6 +23,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+serviceAccount:
+  enabled: false
+  name: ""
+
 initContainers:
   gitSync:
     enabled: false

--- a/charts/ndc-mongodb/Chart.yaml
+++ b/charts/ndc-mongodb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.06.10
+version: v2025.07.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-mongodb/Chart.yaml
+++ b/charts/ndc-mongodb/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-mongodb/Chart.yaml
+++ b/charts/ndc-mongodb/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.30
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-mongodb/README.md
+++ b/charts/ndc-mongodb/README.md
@@ -65,6 +65,36 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -105,3 +135,5 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `initContainers.gitSync.repo`                     | Git repository to read from (Used when initContainers.gitSync.enabled is set to true)                      | `git@github.com:<org>/<repo>`       |
 | `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
 | `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-mongodb/README.md
+++ b/charts/ndc-mongodb/README.md
@@ -65,9 +65,11 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -95,6 +97,20 @@ secrets:
         email: "support@hasura.io"
 ```
 
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -115,6 +131,12 @@ secrets:
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-mongodb                                                     | `""`                                |
 | `image.tag`                                       | Image tag to use for custom created ndc-mongodb                                                            | `""`                                |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                            |

--- a/charts/ndc-mongodb/values.yaml
+++ b/charts/ndc-mongodb/values.yaml
@@ -23,6 +23,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+serviceAccount:
+  enabled: false
+  name: ""
+
 initContainers:
   gitSync:
     enabled: false

--- a/charts/ndc-mysql-jdbc/Chart.yaml
+++ b/charts/ndc-mysql-jdbc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.06.10
+version: v2025.07.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-mysql-jdbc/Chart.yaml
+++ b/charts/ndc-mysql-jdbc/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-mysql-jdbc/Chart.yaml
+++ b/charts/ndc-mysql-jdbc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.30
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-mysql-jdbc/README.md
+++ b/charts/ndc-mysql-jdbc/README.md
@@ -65,6 +65,36 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -105,3 +135,5 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `initContainers.gitSync.repo`                     | Git repository to read from (Used when initContainers.gitSync.enabled is set to true)                      | `git@github.com:<org>/<repo>`       |
 | `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
 | `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-mysql-jdbc/README.md
+++ b/charts/ndc-mysql-jdbc/README.md
@@ -65,9 +65,11 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -95,6 +97,20 @@ secrets:
         email: "support@hasura.io"
 ```
 
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -115,6 +131,12 @@ secrets:
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-mysql-jdbc                                                    | `""`                                |
 | `image.tag`                                       | Image tag to use for custom created ndc-mysql-jdbc                                                           | `""`                                |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                            |

--- a/charts/ndc-mysql-jdbc/values.yaml
+++ b/charts/ndc-mysql-jdbc/values.yaml
@@ -23,6 +23,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+serviceAccount:
+  enabled: false
+  name: ""
+
 initContainers:
   gitSync:
     enabled: false

--- a/charts/ndc-nodejs-lambda/Chart.yaml
+++ b/charts/ndc-nodejs-lambda/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-nodejs-lambda/Chart.yaml
+++ b/charts/ndc-nodejs-lambda/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.30
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-nodejs-lambda/Chart.yaml
+++ b/charts/ndc-nodejs-lambda/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.08
+version: v2025.07.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-nodejs-lambda/README.md
+++ b/charts/ndc-nodejs-lambda/README.md
@@ -71,6 +71,36 @@ If you prefer **not to commit** the `node_modules` directory to your repository,
 - Install your Helm chart with `--set initContainers.gitSync.depsPackaged=false`
   - This tells the system to use the pre-packaged dependencies instead of expecting them in the Git repo.
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -121,3 +151,5 @@ You can pass custom environment variables to the connector container by defining
 | `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
 | `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
 | `initContainers.gitSync.depsPackaged`             | Whether node_modules was packaged into git repo (Used when initContainers.gitSync.enabled is set to true)  | `true`                              |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-nodejs-lambda/README.md
+++ b/charts/ndc-nodejs-lambda/README.md
@@ -71,9 +71,11 @@ If you prefer **not to commit** the `node_modules` directory to your repository,
 - Install your Helm chart with `--set initContainers.gitSync.depsPackaged=false`
   - This tells the system to use the pre-packaged dependencies instead of expecting them in the Git repo.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -99,6 +101,20 @@ secrets:
         password: |
           {}
         email: "support@hasura.io"
+```
+
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
 ```
 
 ## Connector ENV Inputs
@@ -130,6 +146,12 @@ You can pass custom environment variables to the connector container by defining
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-nodejs-lambda                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-nodejs-lambda                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |

--- a/charts/ndc-nodejs-lambda/values.yaml
+++ b/charts/ndc-nodejs-lambda/values.yaml
@@ -23,6 +23,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+serviceAccount:
+  enabled: false
+  name: ""
+
 initContainers:
   gitSync:
     enabled: false

--- a/charts/ndc-open-api-lambda/Chart.yaml
+++ b/charts/ndc-open-api-lambda/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.06.10
+version: v2025.07.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-open-api-lambda/Chart.yaml
+++ b/charts/ndc-open-api-lambda/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-open-api-lambda/Chart.yaml
+++ b/charts/ndc-open-api-lambda/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.30
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-open-api-lambda/README.md
+++ b/charts/ndc-open-api-lambda/README.md
@@ -74,6 +74,36 @@ If you prefer **not to commit** the `node_modules` directory to your repository,
 - Install your Helm chart with `--set initContainers.gitSync.depsPackaged=false`
   - This tells the system to use the pre-packaged dependencies instead of expecting them in the Git repo.
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -128,3 +158,5 @@ You can pass custom environment variables to the connector container by defining
 | `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
 | `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
 | `initContainers.gitSync.depsPackaged`             | Whether node_modules was packaged into git repo (Used when initContainers.gitSync.enabled is set to true)  | `true`                              |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-open-api-lambda/README.md
+++ b/charts/ndc-open-api-lambda/README.md
@@ -74,9 +74,11 @@ If you prefer **not to commit** the `node_modules` directory to your repository,
 - Install your Helm chart with `--set initContainers.gitSync.depsPackaged=false`
   - This tells the system to use the pre-packaged dependencies instead of expecting them in the Git repo.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -102,6 +104,20 @@ secrets:
         password: |
           {}
         email: "support@hasura.io"
+```
+
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
 ```
 
 ## Connector ENV Inputs
@@ -137,6 +153,12 @@ You can pass custom environment variables to the connector container by defining
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-open-api-lambda                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-open-api-lambda                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |

--- a/charts/ndc-open-api-lambda/values.yaml
+++ b/charts/ndc-open-api-lambda/values.yaml
@@ -23,6 +23,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+serviceAccount:
+  enabled: false
+  name: ""
+
 initContainers:
   gitSync:
     enabled: false

--- a/charts/ndc-postgres-jdbc/Chart.yaml
+++ b/charts/ndc-postgres-jdbc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.06.10
+version: v2025.07.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-postgres-jdbc/Chart.yaml
+++ b/charts/ndc-postgres-jdbc/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-postgres-jdbc/Chart.yaml
+++ b/charts/ndc-postgres-jdbc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.30
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-postgres-jdbc/README.md
+++ b/charts/ndc-postgres-jdbc/README.md
@@ -65,6 +65,36 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -106,3 +136,5 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `initContainers.gitSync.repo`                     | Git repository to read from (Used when initContainers.gitSync.enabled is set to true)                      | `git@github.com:<org>/<repo>`       |
 | `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
 | `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-postgres-jdbc/README.md
+++ b/charts/ndc-postgres-jdbc/README.md
@@ -65,9 +65,11 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -95,6 +97,20 @@ secrets:
         email: "support@hasura.io"
 ```
 
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -116,6 +132,12 @@ secrets:
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-postgres-jdbc                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-postgres-jdbc                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |

--- a/charts/ndc-postgres-jdbc/values.yaml
+++ b/charts/ndc-postgres-jdbc/values.yaml
@@ -23,6 +23,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+serviceAccount:
+  enabled: false
+  name: ""
+
 initContainers:
   gitSync:
     enabled: false

--- a/charts/ndc-postgres/Chart.yaml
+++ b/charts/ndc-postgres/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.06.10
+version: v2025.07.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-postgres/Chart.yaml
+++ b/charts/ndc-postgres/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-postgres/Chart.yaml
+++ b/charts/ndc-postgres/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.30
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-postgres/README.md
+++ b/charts/ndc-postgres/README.md
@@ -65,6 +65,36 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -108,3 +138,5 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `initContainers.gitSync.repo`                     | Git repository to read from (Used when initContainers.gitSync.enabled is set to true)                      | `git@github.com:<org>/<repo>`       |
 | `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
 | `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-postgres/README.md
+++ b/charts/ndc-postgres/README.md
@@ -65,9 +65,11 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -95,6 +97,20 @@ secrets:
         email: "support@hasura.io"
 ```
 
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -118,6 +134,12 @@ secrets:
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-postgres                                                    | `""`                            |
 | `image.tag`                                       | Image tag to use for custom created ndc-postgres                                                           | `""`                            |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |

--- a/charts/ndc-postgres/values.yaml
+++ b/charts/ndc-postgres/values.yaml
@@ -23,6 +23,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+serviceAccount:
+  enabled: false
+  name: ""
+
 initContainers:
   gitSync:
     enabled: false

--- a/charts/ndc-snowflake-jdbc/Chart.yaml
+++ b/charts/ndc-snowflake-jdbc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.06.10
+version: v2025.07.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-snowflake-jdbc/Chart.yaml
+++ b/charts/ndc-snowflake-jdbc/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-snowflake-jdbc/Chart.yaml
+++ b/charts/ndc-snowflake-jdbc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.30
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-snowflake-jdbc/README.md
+++ b/charts/ndc-snowflake-jdbc/README.md
@@ -65,6 +65,36 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -106,3 +136,5 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `initContainers.gitSync.repo`                     | Git repository to read from (Used when initContainers.gitSync.enabled is set to true)                      | `git@github.com:<org>/<repo>`       |
 | `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
 | `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-snowflake-jdbc/README.md
+++ b/charts/ndc-snowflake-jdbc/README.md
@@ -65,9 +65,11 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -95,6 +97,20 @@ secrets:
         email: "support@hasura.io"
 ```
 
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -116,6 +132,12 @@ secrets:
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-snowflake-jdbc                                                     | `""`                                |
 | `image.tag`                                       | Image tag to use for custom created ndc-snowflake-jdbc                                                            | `""`                                |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                            |

--- a/charts/ndc-snowflake-jdbc/values.yaml
+++ b/charts/ndc-snowflake-jdbc/values.yaml
@@ -23,6 +23,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+serviceAccount:
+  enabled: false
+  name: ""
+
 initContainers:
   gitSync:
     enabled: false

--- a/charts/ndc-snowflake/Chart.yaml
+++ b/charts/ndc-snowflake/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.06.10
+version: v2025.07.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-snowflake/Chart.yaml
+++ b/charts/ndc-snowflake/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "3.0.0"
 
 dependencies:
 - name: common
-  version: 0.0.13
+  version: 0.0.14
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-snowflake/Chart.yaml
+++ b/charts/ndc-snowflake/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.07.30
+version: v2025.07.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-snowflake/README.md
+++ b/charts/ndc-snowflake/README.md
@@ -65,6 +65,36 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
+## Private Registry Access via Image Pull Secrets
+
+To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -108,3 +138,5 @@ When you enable git-sync, the code will be fetched from the repository specified
 | `initContainers.gitSync.repo`                     | Git repository to read from (Used when initContainers.gitSync.enabled is set to true)                      | `git@github.com:<org>/<repo>`       |
 | `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
 | `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-snowflake/README.md
+++ b/charts/ndc-snowflake/README.md
@@ -65,9 +65,11 @@ helm upgrade --install <release-name> \
 
 When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
 
-## Private Registry Access via Image Pull Secrets
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
 
-To pull container images from a private registry, you can configure an image pull secret using the following example `overrides.yaml` file.  This is typically required during the installation phase when the image (e.g., a connector) resides in a restricted registry.
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
 
 ```yaml
 global:
@@ -95,6 +97,20 @@ secrets:
         email: "support@hasura.io"
 ```
 
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
+```
+
 ## Connector ENV Inputs
 
 | Name                                              | Description                                                                                                | Value                           |
@@ -118,6 +134,12 @@ secrets:
 | `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
 | `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
 | `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
 | `image.repository`                                | Image repository containing custom created ndc-snowflake                                                     | `""`                                |
 | `image.tag`                                       | Image tag to use for custom created ndc-snowflake                                                            | `""`                                |
 | `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                            |

--- a/charts/ndc-snowflake/values.yaml
+++ b/charts/ndc-snowflake/values.yaml
@@ -23,6 +23,10 @@ securityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+serviceAccount:
+  enabled: false
+  name: ""
+
 initContainers:
   gitSync:
     enabled: false

--- a/tests/ndc-connector-oracle-git-sync-values.yaml
+++ b/tests/ndc-connector-oracle-git-sync-values.yaml
@@ -1,0 +1,14 @@
+image:
+  repository: "my_repo/ndc-connector-oracle"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+  configDirectory: "/work-dir/<repo>/app/connector/<connector-name>"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-connector-oracle-values.yaml
+++ b/tests/ndc-connector-oracle-values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: "my_repo/ndc-connector-oracle"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-connector-phoenix-git-sync-values.yaml
+++ b/tests/ndc-connector-phoenix-git-sync-values.yaml
@@ -1,0 +1,13 @@
+image:
+  repository: "my_repo/ndc-connector-phoenix"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-connector-phoenix-values.yaml
+++ b/tests/ndc-connector-phoenix-values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: "my_repo/ndc-connector-phoenix"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-duckduckapi-git-sync-values.yaml
+++ b/tests/ndc-duckduckapi-git-sync-values.yaml
@@ -1,0 +1,12 @@
+image:
+  repository: "my_repo/ndc-duckduckapi"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-duckduckapi-values.yaml
+++ b/tests/ndc-duckduckapi-values.yaml
@@ -1,0 +1,6 @@
+image:
+  repository: "my_repo/ndc-duckduckapi"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-elasticsearch-git-sync-values.yaml
+++ b/tests/ndc-elasticsearch-git-sync-values.yaml
@@ -1,0 +1,15 @@
+image:
+  repository: "my_repo/ndc-elasticsearch"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  ELASTICSEARCH_URL: "elasticsearch_url"
+  ELASTICSEARCH_USERNAME: "elasticsearch_username"
+  ELASTICSEARCH_PASSWORD: "elasticsearch_password"
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-elasticsearch-values.yaml
+++ b/tests/ndc-elasticsearch-values.yaml
@@ -1,0 +1,9 @@
+image:
+  repository: "my_repo/ndc-elasticsearch"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  ELASTICSEARCH_URL: "elasticsearch_url"
+  ELASTICSEARCH_USERNAME: "elasticsearch_username"
+  ELASTICSEARCH_PASSWORD: "elasticsearch_password"
+  HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-graphql-git-sync-values.yaml
+++ b/tests/ndc-graphql-git-sync-values.yaml
@@ -1,0 +1,13 @@
+image:
+  repository: "my_repo/ndc-graphql"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  GRAPHQL_ENDPOINT: "graphql_endpoint"
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-graphql-values.yaml
+++ b/tests/ndc-graphql-values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: "my_repo/ndc-graphql"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  GRAPHQL_ENDPOINT: "graphql_endpoint"
+  HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-http-git-sync-values.yaml
+++ b/tests/ndc-http-git-sync-values.yaml
@@ -1,0 +1,12 @@
+image:
+  repository: "my_repo/ndc-http"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-http-values.yaml
+++ b/tests/ndc-http-values.yaml
@@ -1,0 +1,6 @@
+image:
+  repository: "my_repo/ndc-http"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-jvm-mysql-git-sync-values.yaml
+++ b/tests/ndc-jvm-mysql-git-sync-values.yaml
@@ -1,0 +1,13 @@
+image:
+  repository: "my_repo/ndc-jvm-mysql"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-jvm-mysql-values.yaml
+++ b/tests/ndc-jvm-mysql-values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: "my_repo/ndc-jvm-mysql"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-jvm-trino-git-sync-values.yaml
+++ b/tests/ndc-jvm-trino-git-sync-values.yaml
@@ -1,13 +1,10 @@
 image:
-  repository: "my_repo/ndc-bigquery"
+  repository: "my_repo/ndc-jvm-trino"
   tag: "v1.0.0"
 
 connectorEnvVars:
-  HASURA_BIGQUERY_SERVICE_KEY: "bg_service_key"
-  HASURA_BIGQUERY_PROJECT_ID: "bg_project_id"
-  HASURA_BIGQUERY_DATASET_ID: "bq_dataset_id"
+  JDBC_URL: "jdbc_url"
   HASURA_SERVICE_TOKEN_SECRET: "token"
-  configDirectory: "/work-dir/<repo>/app/connector/<connector-name>"
 
 initContainers:
   gitSync:

--- a/tests/ndc-jvm-trino-git-sync-values.yaml
+++ b/tests/ndc-jvm-trino-git-sync-values.yaml
@@ -1,0 +1,16 @@
+image:
+  repository: "my_repo/ndc-bigquery"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  HASURA_BIGQUERY_SERVICE_KEY: "bg_service_key"
+  HASURA_BIGQUERY_PROJECT_ID: "bg_project_id"
+  HASURA_BIGQUERY_DATASET_ID: "bq_dataset_id"
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+  configDirectory: "/work-dir/<repo>/app/connector/<connector-name>"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-jvm-trino-values.yaml
+++ b/tests/ndc-jvm-trino-values.yaml
@@ -1,9 +1,7 @@
 image:
-  repository: "my_repo/ndc-bigquery"
+  repository: "my_repo/ndc-jvm-trino"
   tag: "v1.0.0"
 
 connectorEnvVars:
-  HASURA_BIGQUERY_SERVICE_KEY: "bg_service_key"
-  HASURA_BIGQUERY_PROJECT_ID: "bg_project_id"
-  HASURA_BIGQUERY_DATASET_ID: "bq_dataset_id"
+  JDBC_URL: "jdbc_url"
   HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-jvm-trino-values.yaml
+++ b/tests/ndc-jvm-trino-values.yaml
@@ -1,0 +1,9 @@
+image:
+  repository: "my_repo/ndc-bigquery"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  HASURA_BIGQUERY_SERVICE_KEY: "bg_service_key"
+  HASURA_BIGQUERY_PROJECT_ID: "bg_project_id"
+  HASURA_BIGQUERY_DATASET_ID: "bq_dataset_id"
+  HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-mongodb-git-sync-values.yaml
+++ b/tests/ndc-mongodb-git-sync-values.yaml
@@ -1,0 +1,13 @@
+image:
+  repository: "my_repo/ndc-mongodb"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  MONGODB_DATABASE_URI: "db_connection_string"
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-mongodb-values.yaml
+++ b/tests/ndc-mongodb-values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: "my_repo/ndc-mongodb"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  MONGODB_DATABASE_URI: "db_connection_string"
+  HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-mysql-jdbc-git-sync-values.yaml
+++ b/tests/ndc-mysql-jdbc-git-sync-values.yaml
@@ -1,0 +1,13 @@
+image:
+  repository: "my_repo/ndc-mysql-jdbc"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-mysql-jdbc-values.yaml
+++ b/tests/ndc-mysql-jdbc-values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: "my_repo/ndc-mysql-jdbc"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-nodejs-lambda-git-sync-values.yaml
+++ b/tests/ndc-nodejs-lambda-git-sync-values.yaml
@@ -1,0 +1,12 @@
+image:
+  repository: "my_repo/ndc-nodejs-lambda"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-nodejs-lambda-values.yaml
+++ b/tests/ndc-nodejs-lambda-values.yaml
@@ -1,0 +1,6 @@
+image:
+  repository: "my_repo/ndc-nodejs-lambda"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-open-api-lambda-git-sync-values.yaml
+++ b/tests/ndc-open-api-lambda-git-sync-values.yaml
@@ -1,0 +1,13 @@
+image:
+  repository: "my_repo/ndc-nodejs-lambda"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  NDC_OAS_BASE_URL: "ndc_oas_base_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-open-api-lambda-values.yaml
+++ b/tests/ndc-open-api-lambda-values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: "my_repo/ndc-nodejs-lambda"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  NDC_OAS_BASE_URL: "ndc_oas_base_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-postgres-git-sync-values.yaml
+++ b/tests/ndc-postgres-git-sync-values.yaml
@@ -1,0 +1,13 @@
+image:
+  repository: "my_repo/ndc-postgres"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  CONNECTION_URI: "db_connection_string"
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-postgres-jdbc-git-sync-values.yaml
+++ b/tests/ndc-postgres-jdbc-git-sync-values.yaml
@@ -1,0 +1,13 @@
+image:
+  repository: "my_repo/ndc-ppostgres-jdbc"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-postgres-jdbc-values.yaml
+++ b/tests/ndc-postgres-jdbc-values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: "my_repo/ndc-ppostgres-jdbc"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-postgres-values.yaml
+++ b/tests/ndc-postgres-values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: "my_repo/ndc-postgres"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  CONNECTION_URI: "db_connection_string"
+  HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-snowflake-git-sync-values.yaml
+++ b/tests/ndc-snowflake-git-sync-values.yaml
@@ -1,0 +1,13 @@
+image:
+  repository: "my_repo/ndc-snowflake"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-snowflake-jdbc-git-sync-values.yaml
+++ b/tests/ndc-snowflake-jdbc-git-sync-values.yaml
@@ -1,0 +1,13 @@
+image:
+  repository: "my_repo/ndc-snowflake-jdbc"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-snowflake-jdbc-values.yaml
+++ b/tests/ndc-snowflake-jdbc-values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: "my_repo/ndc-snowflake-jdbc"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"

--- a/tests/ndc-snowflake-values.yaml
+++ b/tests/ndc-snowflake-values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: "my_repo/ndc-snowflake"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"


### PR DESCRIPTION
- Add `helm template` tests for all connectors (git-sync and non git-sync tests)
- Create helm chart for `ndc-http`
- Add support for service account under all connectors
- Document in connector README's usage of image pull secret
- Bump `common` from `0.0.13` to `0.0.14` on connectors