### PR TITLE
feat: add promptql-shelf helm chart

### DIFF
--- a/charts/promptql-shelf/.helmignore
+++ b/charts/promptql-shelf/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/promptql-shelf/Chart.yaml
+++ b/charts/promptql-shelf/Chart.yaml
@@ -24,6 +24,9 @@ version: 0.1.0
 appVersion: "1.16.0"
 
 dependencies:
+  - name: common
+    version: 0.0.16
+    repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts
   - name: lakekeeper
     version: 0.8.1
     repository: https://lakekeeper.github.io/lakekeeper-charts/

--- a/charts/promptql-shelf/Chart.yaml
+++ b/charts/promptql-shelf/Chart.yaml
@@ -1,0 +1,34 @@
+apiVersion: v2
+name: promptql-shelf
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"
+
+dependencies:
+  - name: lakekeeper
+    version: 0.8.1
+    repository: https://lakekeeper.github.io/lakekeeper-charts/
+    condition: lakekeeper.enabled
+  - name: trino
+    version: 1.41.0
+    repository: https://trinodb.github.io/charts/
+    condition: trino.enabled

--- a/charts/promptql-shelf/README.md
+++ b/charts/promptql-shelf/README.md
@@ -1,0 +1,62 @@
+# promptql-shelf
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+
+A Helm chart for Kubernetes
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://lakekeeper.github.io/lakekeeper-charts/ | lakekeeper | 0.8.1 |
+| https://trinodb.github.io/charts/ | trino | 1.41.0 |
+| oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts | common | 0.0.16 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| lakekeeper.authz.backend | string | `"allowall"` | Authorization backend type |
+| lakekeeper.bootstrap.annotations | object | `{"helm.sh/hook":"post-install","helm.sh/hook-delete-policy":"before-hook-creation"}` | Annotations for the bootstrap job |
+| lakekeeper.bootstrap.apiUrl | string | `"http://lakekeeper.promptql.svc.cluster.local:8181"` | API URL for lakekeeper bootstrap |
+| lakekeeper.bootstrap.azdlsFilesystem | string | `""` | Azure Data Lake Storage filesystem name (Azure) |
+| lakekeeper.bootstrap.azdlsStorageAccount | string | `""` | Azure Data Lake Storage account name (Azure) |
+| lakekeeper.bootstrap.cloud | string | `"aws"` | Cloud provider for bootstrap (aws, gcp, azure) |
+| lakekeeper.bootstrap.gcsBucket | string | `""` | GCS bucket name for storage (GCP) |
+| lakekeeper.bootstrap.s3Bucket | string | `""` | S3 bucket name for storage (AWS) |
+| lakekeeper.bootstrap.s3Region | string | `""` | S3 region for storage (AWS) |
+| lakekeeper.bootstrap.warehouseName | string | `"iceberg"` | Warehouse name for Iceberg catalog |
+| lakekeeper.catalog.config | object | `{"LAKEKEEPER__ENABLE_AWS_SYSTEM_CREDENTIALS":"true","LAKEKEEPER__ENABLE_AZURE_SYSTEM_CREDENTIALS":"true","LAKEKEEPER__ENABLE_GCP_SYSTEM_CREDENTIALS":"true"}` | Catalog configuration environment variables |
+| lakekeeper.catalog.replicas | int | `2` | Number of replicas to deploy. Replicas are stateless. |
+| lakekeeper.catalog.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | Resource limits and requests for the catalog container |
+| lakekeeper.enabled | bool | `true` | Enable or disable the lakekeeper subchart |
+| lakekeeper.externalDatabase.database | string | `"lakekeeper"` | The database/schema to use within the external database |
+| lakekeeper.externalDatabase.host_read | string | `""` | hostname to use for read instances of the external database |
+| lakekeeper.externalDatabase.host_write | string | `""` | hostname to use for write instances of the external database. For single read/write instances, this should be the same as `host_read` |
+| lakekeeper.externalDatabase.password | string | `""` | The password for the external database. |
+| lakekeeper.externalDatabase.port | int | `5432` | Port of the external database |
+| lakekeeper.externalDatabase.type | string | `"postgres"` | the type of external database. allowed values: "postgres" |
+| lakekeeper.externalDatabase.user | string | `""` | The username for the external database |
+| lakekeeper.fullnameOverride | string | `"lakekeeper"` | Override the fullname of lakekeeper resources |
+| lakekeeper.pgEncryptionKey | string | `""` | PostgreSQL encryption key (leave empty to use secret) |
+| lakekeeper.postgresql.enabled | bool | `false` | Enable built-in PostgreSQL (set to false when using external database) |
+| lakekeeper.preInstallMigration.annotations | object | `{"helm.sh/hook":"pre-install","helm.sh/hook-delete-policy":"before-hook-creation"}` | Annotations for the pre-install migration job |
+| lakekeeper.secretBackend.postgres.encryptionKeySecret | string | `"lakekeeper-pg-encryption"` | Name of the secret containing the encryption key. (Mandatory) |
+| lakekeeper.secretBackend.postgres.encryptionKeySecretKey | string | `"encryptionKey"` | Name of the key within `encryptionKeySecret` containing the encryption key string |
+| lakekeeper.secretBackend.type | string | `"Postgres"` | the type of secret store to use. Available values: "Postgres", "KV2" |
+| lakekeeper.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. If `false`, you must create the service account outside this chart with name: `serviceAccount.name` |
+| trino.catalogs | string | `""` | Trino catalogs configuration |
+| trino.cloud | string | `"aws"` | Cloud provider for trino (aws, gcp, azure) |
+| trino.coordinator.additionalVolumeMounts | list | `[{"mountPath":"/etc/trino/catalog","name":"trino-catalog"}]` | Additional volume mounts for the coordinator container |
+| trino.coordinator.additionalVolumes | list | `[{"configMap":{"name":"trino-catalog"},"name":"trino-catalog"}]` | Additional volumes for the coordinator pod |
+| trino.coordinator.resources | object | `{"limits":{"cpu":"2000m","memory":"4Gi"},"requests":{"cpu":"1000m","memory":"2Gi"}}` | Resource limits and requests for the coordinator container |
+| trino.enabled | bool | `true` | Enable or disable the trino subchart |
+| trino.fullnameOverride | string | `"trino"` | Override the fullname of trino resources |
+| trino.serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| trino.serviceAccount.name | string | `"trino"` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| trino.worker.additionalVolumeMounts | list | `[{"mountPath":"/etc/trino/catalog","name":"trino-catalog"}]` | Additional volume mounts for the worker containers |
+| trino.worker.additionalVolumes | list | `[{"configMap":{"name":"trino-catalog"},"name":"trino-catalog"}]` | Additional volumes for the worker pods |
+| trino.worker.resources | object | `{"limits":{"cpu":"4000m","memory":"8Gi"},"requests":{"cpu":"2000m","memory":"4Gi"}}` | Resource limits and requests for the worker containers |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/promptql-shelf/templates/lakekeeper-bootstrap.yaml
+++ b/charts/promptql-shelf/templates/lakekeeper-bootstrap.yaml
@@ -1,0 +1,164 @@
+{{ $name := "lakekeeper-bootstrap" }}
+{{ $namespace := .Release.Namespace }}
+{{ $labels := include "common.labels" . }}
+---
+{{- if .Values.lakekeeper.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  namespace: {{ $namespace }}
+  labels:
+    {{- $labels | nindent 4 }}
+  annotations: {{- toYaml .Values.lakekeeper.bootstrap.annotations | nindent 4 }}
+{{- end }}
+---
+{{- if .Values.lakekeeper.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}
+  namespace: {{ $namespace }}
+  labels:
+    {{- $labels | nindent 4 }}
+  annotations: {{- toYaml .Values.lakekeeper.bootstrap.annotations | nindent 4 }}
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ $name }}
+      {{- if .Values.lakekeeper.catalog.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.lakekeeper.catalog.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.lakekeeper.catalog.affinity }}
+      affinity: {{- toYaml .Values.lakekeeper.catalog.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.lakekeeper.catalog.tolerations }}
+      tolerations: {{- toYaml .Values.lakekeeper.catalog.tolerations | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: provision-warehouse
+          image: nicolaka/netshoot:v0.14
+          env:
+            - name: API_URL
+              value: {{ .Values.lakekeeper.bootstrap.apiUrl }}
+            - name: WAREHOUSE_NAME
+              value: {{ .Values.lakekeeper.bootstrap.warehouseName }}
+            {{- if eq .Values.lakekeeper.bootstrap.cloud "aws" }}
+            - name: S3_BUCKET
+              value: {{ .Values.lakekeeper.bootstrap.s3Bucket }}
+            - name: S3_REGION
+              value: {{ .Values.lakekeeper.bootstrap.s3Region }}
+            {{- else if eq .Values.lakekeeper.bootstrap.cloud "gcp" }}
+            - name: GCS_BUCKET
+              value: {{ .Values.lakekeeper.bootstrap.gcsBucket }}
+            {{- else if eq .Values.lakekeeper.bootstrap.cloud "azure" }}
+            - name: AZDLS_FILESYSTEM
+              value: {{ .Values.lakekeeper.bootstrap.azdlsFilesystem }}
+            - name: AZDLS_STORAGE_ACCOUNT
+              value: {{ .Values.lakekeeper.bootstrap.azdlsStorageAccount }}
+            {{- end }}
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -e
+
+              check_error() {
+                local response="$1"
+                local operation="$2"
+                if echo "$response" | jq -e '.error' > /dev/null 2>&1; then
+                  echo "ERROR: $operation failed:"
+                  echo "$response" | jq .
+                  exit 1
+                fi
+              }
+
+              INFO_RESPONSE=$(curl -s -X GET "$API_URL/management/v1/info" \
+                -H "Authorization: Bearer $TOKEN")
+              check_error "$INFO_RESPONSE" "Get info"
+              BOOTSTRAPPED=$(echo "$INFO_RESPONSE" | jq -r ".bootstrapped")
+
+              if [ "$BOOTSTRAPPED" = "false" ]; then
+                echo "System not bootstrapped. Bootstrapping..."
+                BOOTSTRAP_RESPONSE=$(curl -s -X POST "$API_URL/management/v1/bootstrap" \
+                  -H "Content-Type: application/json" \
+                  -d '{"accept-terms-of-use": true}')
+                echo "Bootstrap response: $BOOTSTRAP_RESPONSE"
+                check_error "$BOOTSTRAP_RESPONSE" "Bootstrap"
+              else
+                echo "System already bootstrapped."
+              fi
+
+              WAREHOUSE_CHECK=$(curl -s -X GET "$API_URL/management/v1/warehouse" \
+                -H "Authorization: Bearer $TOKEN")
+              echo "Warehouse check response: $WAREHOUSE_CHECK"
+              check_error "$WAREHOUSE_CHECK" "List warehouses"
+              if echo "$WAREHOUSE_CHECK" | jq -e ".warehouses[] | select(.name == \"$WAREHOUSE_NAME\")" > /dev/null; then
+                echo "Warehouse $WAREHOUSE_NAME already exists. Skipping creation."
+              else
+                echo "Creating warehouse $WAREHOUSE_NAME..."
+                {{- if eq .Values.lakekeeper.bootstrap.cloud "aws" }}
+                CREATE_RESPONSE=$(curl -s -X POST "$API_URL/management/v1/warehouse" \
+                  -H "x-project-id: 00000000-0000-0000-0000-000000000000" \
+                  -H "Content-Type: application/json" \
+                  -d "{
+                    \"delete-profile\": {\"type\": \"hard\"},
+                    \"warehouse-name\": \"${WAREHOUSE_NAME}\",
+                    \"project-id\": \"00000000-0000-0000-0000-000000000000\",
+                    \"storage-credential\": {
+                      \"type\": \"s3\",
+                      \"credential-type\": \"aws-system-identity\",
+                      \"external-id\": \"lakekeeper\"
+                    },
+                    \"storage-profile\": {
+                      \"type\": \"s3\",
+                      \"bucket\": \"${S3_BUCKET}\",
+                      \"region\": \"${S3_REGION}\",
+                      \"sts-enabled\": false,
+                      \"flavor\": \"aws\",
+                      \"key-prefix\": \"iceberg\"
+                    }
+                  }")
+                {{- else if eq .Values.lakekeeper.bootstrap.cloud "gcp" }}
+                CREATE_RESPONSE=$(curl -s -X POST "$API_URL/management/v1/warehouse" \
+                  -H "x-project-id: 00000000-0000-0000-0000-000000000000" \
+                  -H "Content-Type: application/json" \
+                  -d "{
+                    \"delete-profile\": {\"type\": \"hard\"},
+                    \"warehouse-name\": \"${WAREHOUSE_NAME}\",
+                    \"project-id\": \"00000000-0000-0000-0000-000000000000\",
+                    \"storage-credential\": {
+                      \"credential-type\": \"gcp-system-identity\",
+                      \"type\": \"gcs\"
+                    },
+                    \"storage-profile\": {
+                      \"type\": \"gcs\",
+                      \"bucket\": \"${GCS_BUCKET}\",
+                      \"key-prefix\": \"iceberg\"
+                    }
+                  }")
+                {{- else if eq .Values.lakekeeper.bootstrap.cloud "azure" }}
+                CREATE_RESPONSE=$(curl -s -X POST "$API_URL/management/v1/warehouse" \
+                  -H "x-project-id: 00000000-0000-0000-0000-000000000000" \
+                  -H "Content-Type: application/json" \
+                  -d "{
+                    \"delete-profile\": {\"type\": \"hard\"},
+                    \"warehouse-name\": \"${WAREHOUSE_NAME}\",
+                    \"project-id\": \"00000000-0000-0000-0000-000000000000\",
+                    \"storage-credential\": {
+                      \"credential-type\": \"azure-system-identity\",
+                      \"type\": \"az\"
+                    },
+                    \"storage-profile\": {
+                      \"type\": \"adls\",
+                      \"filesystem\": \"${AZDLS_FILESYSTEM}\",
+                      \"account-name\": \"${AZDLS_STORAGE_ACCOUNT}\",
+                      \"key-prefix\": \"iceberg\"
+                    }
+                  }")
+                {{- end }}
+                echo "Create warehouse response: $CREATE_RESPONSE"
+                check_error "$CREATE_RESPONSE" "Create warehouse"
+                echo "Warehouse $WAREHOUSE_NAME created successfully."
+              fi
+{{- end }}

--- a/charts/promptql-shelf/templates/lakekeeper-bootstrap.yaml
+++ b/charts/promptql-shelf/templates/lakekeeper-bootstrap.yaml
@@ -73,8 +73,7 @@ spec:
                 fi
               }
 
-              INFO_RESPONSE=$(curl -s -X GET "$API_URL/management/v1/info" \
-                -H "Authorization: Bearer $TOKEN")
+              INFO_RESPONSE=$(curl -s -X GET "$API_URL/management/v1/info")
               check_error "$INFO_RESPONSE" "Get info"
               BOOTSTRAPPED=$(echo "$INFO_RESPONSE" | jq -r ".bootstrapped")
 
@@ -89,8 +88,7 @@ spec:
                 echo "System already bootstrapped."
               fi
 
-              WAREHOUSE_CHECK=$(curl -s -X GET "$API_URL/management/v1/warehouse" \
-                -H "Authorization: Bearer $TOKEN")
+              WAREHOUSE_CHECK=$(curl -s -X GET "$API_URL/management/v1/warehouse")
               echo "Warehouse check response: $WAREHOUSE_CHECK"
               check_error "$WAREHOUSE_CHECK" "List warehouses"
               if echo "$WAREHOUSE_CHECK" | jq -e ".warehouses[] | select(.name == \"$WAREHOUSE_NAME\")" > /dev/null; then

--- a/charts/promptql-shelf/templates/lakekeeper-pg-encryption-secret.yaml
+++ b/charts/promptql-shelf/templates/lakekeeper-pg-encryption-secret.yaml
@@ -1,0 +1,16 @@
+{{ $name := "lakekeeper-pg-encryption" }}
+{{ $namespace := .Release.Namespace }}
+{{ $labels := include "common.labels" . }}
+---
+{{ if and .Values.lakekeeper.enabled .Values.lakekeeper.pgEncryptionKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  namespace: {{ $namespace }}
+  labels:
+    {{- $labels | nindent 4 }}
+type: Opaque
+data:
+  encryptionKey: {{ .Values.lakekeeper.pgEncryptionKey | b64enc | quote }}
+{{- end }}

--- a/charts/promptql-shelf/templates/lakekeeper-preinstall-migration.yaml
+++ b/charts/promptql-shelf/templates/lakekeeper-preinstall-migration.yaml
@@ -1,0 +1,51 @@
+{{ $name := "lakekeeper-preinstall-migration" }}
+{{ $namespace := .Release.Namespace }}
+{{ $labels := include "common.labels" . }}
+---
+{{- if .Values.lakekeeper.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}
+  namespace: {{ $namespace }}
+  labels:
+    {{- $labels | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.lakekeeper.preInstallMigration.annotations | nindent 4 }}
+spec:
+  template:
+    spec:
+      containers:
+        - name: check-create-db
+          image: postgres:16.4
+          command: ["sh", "-c"]
+          args:
+            - |
+              echo "Checking if 'lakekeeper' database exists..."
+              if PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d postgres -c "SELECT 1 FROM pg_database WHERE datname = 'lakekeeper'" | grep -q 1; then
+              echo "'lakekeeper' database already exists."
+              else
+              echo "'lakekeeper' database does not exist. Creating..."
+              PGPASSWORD=$DB_PASSWORD psql -h $DB_HOST -p $DB_PORT -U $DB_USER -d postgres -c "CREATE DATABASE lakekeeper"
+              echo "'lakekeeper' database created."
+              fi
+          env:
+            - name: DB_HOST
+              value: {{ .Values.lakekeeper.externalDatabase.host_write }}
+            - name: DB_PORT
+              value: {{ .Values.lakekeeper.externalDatabase.port | quote }}
+            - name: DB_USER
+              value: {{ .Values.lakekeeper.externalDatabase.user }}
+            - name: DB_PASSWORD
+              value: {{ .Values.lakekeeper.externalDatabase.password }}
+      restartPolicy: OnFailure
+      {{- if .Values.lakekeeper.catalog.nodeSelector }}
+      nodeSelector: {{- toYaml .Values.lakekeeper.catalog.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.lakekeeper.catalog.affinity }}
+      affinity: {{- toYaml .Values.lakekeeper.catalog.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.lakekeeper.catalog.tolerations }}
+      tolerations: {{- toYaml .Values.lakekeeper.catalog.tolerations | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/promptql-shelf/templates/trino-catalog-configmap.yaml
+++ b/charts/promptql-shelf/templates/trino-catalog-configmap.yaml
@@ -1,0 +1,39 @@
+{{ $name := "trino-catalog" }}
+{{ $namespace := .Release.Namespace }}
+{{ $labels := include "common.labels" . }}
+---
+{{- if .Values.trino.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  namespace: {{ $namespace }}
+  labels:
+    {{- $labels | nindent 4 }}
+data:
+  iceberg.properties: |
+    connector.name=iceberg
+    iceberg.catalog.type=rest
+    iceberg.rest-catalog.uri=http://lakekeeper.promptql.svc.cluster.local:8181/catalog
+    iceberg.rest-catalog.warehouse=iceberg
+    iceberg.compression-codec=ZSTD
+    iceberg.register-table-procedure.enabled=true
+    iceberg.target-max-file-size=512MB
+    iceberg.max-partitions-per-writer=500
+    {{- if eq .Values.trino.cloud "aws" }}
+    fs.native-s3.enabled=true
+    {{- else if eq .Values.trino.cloud "gcp" }}
+    fs.native-gcs.enabled=true
+    gcs.auth-type=APPLICATION_DEFAULT
+    {{- else if eq .Values.trino.cloud "azure" }}
+    fs.native-azure.enabled=true
+    {{- end }}
+
+  tpcds.properties: |
+    connector.name=tpcds
+    tpcds.splits-per-node=4
+
+  tpch.properties: |
+    connector.name=tpch
+    tpch.splits-per-node=4
+{{- end }}

--- a/charts/promptql-shelf/values.yaml
+++ b/charts/promptql-shelf/values.yaml
@@ -1,24 +1,40 @@
 lakekeeper:
+  # -- Enable or disable the lakekeeper subchart
   enabled: true
+  # -- PostgreSQL encryption key (leave empty to use secret)
   pgEncryptionKey: ""
+  # -- Override the fullname of lakekeeper resources
   fullnameOverride: "lakekeeper"
   preInstallMigration:
+    # -- Annotations for the pre-install migration job
     annotations:
       helm.sh/hook: pre-install
       helm.sh/hook-delete-policy: before-hook-creation
   bootstrap:
+    # -- Cloud provider for bootstrap (aws, gcp, azure)
     cloud: "aws"
+    # -- API URL for lakekeeper bootstrap
     apiUrl: "http://lakekeeper.promptql.svc.cluster.local:8181"
+    # -- Warehouse name for Iceberg catalog
     warehouseName: "iceberg"
+    # -- S3 bucket name for storage (AWS)
     s3Bucket: ""
+    # -- S3 region for storage (AWS)
     s3Region: ""
+    # -- GCS bucket name for storage (GCP)
+    gcsBucket: ""
+    # -- Azure Data Lake Storage filesystem name (Azure)
+    azdlsFilesystem: ""
+    # -- Azure Data Lake Storage account name (Azure)
+    azdlsStorageAccount: ""
+    # -- Annotations for the bootstrap job
     annotations:
       helm.sh/hook: post-install
       helm.sh/hook-delete-policy: before-hook-creation
   catalog:
     # -- Number of replicas to deploy. Replicas are stateless.
     replicas: 2
-
+    # -- Resource limits and requests for the catalog container
     resources:
       limits:
         cpu: 500m
@@ -26,6 +42,7 @@ lakekeeper:
       requests:
         cpu: 250m
         memory: 256Mi
+    # -- Catalog configuration environment variables
     config:
       LAKEKEEPER__ENABLE_AWS_SYSTEM_CREDENTIALS: "true"
       LAKEKEEPER__ENABLE_GCP_SYSTEM_CREDENTIALS: "true"
@@ -44,6 +61,7 @@ lakekeeper:
       encryptionKeySecretKey: "encryptionKey"
 
   postgresql:
+    # -- Enable built-in PostgreSQL (set to false when using external database)
     enabled: false
 
   externalDatabase:
@@ -58,21 +76,20 @@ lakekeeper:
     # For single read/write instances, this should be the same as `host_read`
     host_write: ""
 
-    # port of the external database
+    # -- Port of the external database
     port: 5432
 
-    # the database/scheme to use within the external database
+    # -- The database/schema to use within the external database
     database: lakekeeper
 
-    # the username for the external database
+    # -- The username for the external database
     user: ""
 
-    # the password for the external database
-    # - [WARNING] to avoid storing the password in plain-text within your values,
-    #   create a Kubernetes secret and use `externalDatabase.passwordSecret`
+    # -- The password for the external database.
     password: ""
 
   authz:
+    # -- Authorization backend type
     backend: "allowall"
 
   serviceAccount:
@@ -81,12 +98,17 @@ lakekeeper:
     create: true
 
 trino:
-  enabled: false
+  # -- Enable or disable the trino subchart
+  enabled: true
+  # -- Cloud provider for trino (aws, gcp, azure)
   cloud: "aws"
+  # -- Override the fullname of trino resources
   fullnameOverride: "trino"
+  # -- Trino catalogs configuration
   catalogs: ""
 
   coordinator:
+    # -- Resource limits and requests for the coordinator container
     resources:
       requests:
         cpu: 1000m
@@ -94,15 +116,18 @@ trino:
       limits:
         cpu: 2000m
         memory: 4Gi
+    # -- Additional volumes for the coordinator pod
     additionalVolumes:
       - name: trino-catalog
         configMap:
           name: trino-catalog
+    # -- Additional volume mounts for the coordinator container
     additionalVolumeMounts:
       - name: trino-catalog
         mountPath: /etc/trino/catalog
 
   worker:
+    # -- Resource limits and requests for the worker containers
     resources:
       requests:
         cpu: 2000m
@@ -110,10 +135,12 @@ trino:
       limits:
         cpu: 4000m
         memory: 8Gi
+    # -- Additional volumes for the worker pods
     additionalVolumes:
       - name: trino-catalog
         configMap:
           name: trino-catalog
+    # -- Additional volume mounts for the worker containers
     additionalVolumeMounts:
       - name: trino-catalog
         mountPath: /etc/trino/catalog

--- a/charts/promptql-shelf/values.yaml
+++ b/charts/promptql-shelf/values.yaml
@@ -31,7 +31,6 @@ lakekeeper:
       LAKEKEEPER__ENABLE_GCP_SYSTEM_CREDENTIALS: "true"
       LAKEKEEPER__ENABLE_AZURE_SYSTEM_CREDENTIALS: "true"
 
-
   secretBackend:
     # -- the type of secret store to use.
     # Available values: "Postgres", "KV2"
@@ -78,7 +77,7 @@ lakekeeper:
 
   serviceAccount:
     # -- Specifies whether a service account should be created.
-    # If `false`, you must create the you must create the service account outside this chart with name: `serviceAccount.name`
+    # If `false`, you must create the service account outside this chart with name: `serviceAccount.name`
     create: true
 
 trino:

--- a/charts/promptql-shelf/values.yaml
+++ b/charts/promptql-shelf/values.yaml
@@ -1,0 +1,127 @@
+lakekeeper:
+  enabled: true
+  pgEncryptionKey: ""
+  fullnameOverride: "lakekeeper"
+  preInstallMigration:
+    annotations:
+      helm.sh/hook: pre-install
+      helm.sh/hook-delete-policy: before-hook-creation
+  bootstrap:
+    cloud: "aws"
+    apiUrl: "http://lakekeeper.promptql.svc.cluster.local:8181"
+    warehouseName: "iceberg"
+    s3Bucket: ""
+    s3Region: ""
+    annotations:
+      helm.sh/hook: post-install
+      helm.sh/hook-delete-policy: before-hook-creation
+  catalog:
+    # -- Number of replicas to deploy. Replicas are stateless.
+    replicas: 2
+
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    config:
+      LAKEKEEPER__ENABLE_AWS_SYSTEM_CREDENTIALS: "true"
+      LAKEKEEPER__ENABLE_GCP_SYSTEM_CREDENTIALS: "true"
+      LAKEKEEPER__ENABLE_AZURE_SYSTEM_CREDENTIALS: "true"
+
+
+  secretBackend:
+    # -- the type of secret store to use.
+    # Available values: "Postgres", "KV2"
+    type: "Postgres"
+
+    # postgres specific configurations.
+    postgres:
+      # -- Name of the secret containing the encryption key. (Mandatory)
+      encryptionKeySecret: "lakekeeper-pg-encryption"
+      # -- Name of the key within `encryptionKeySecret` containing the encryption key string
+      encryptionKeySecretKey: "encryptionKey"
+
+  postgresql:
+    enabled: false
+
+  externalDatabase:
+    # -- the type of external database.
+    # allowed values: "postgres"
+    type: postgres
+
+    # -- hostname to use for read instances of the external database
+    host_read: ""
+
+    # -- hostname to use for write instances of the external database.
+    # For single read/write instances, this should be the same as `host_read`
+    host_write: ""
+
+    # port of the external database
+    port: 5432
+
+    # the database/scheme to use within the external database
+    database: lakekeeper
+
+    # the username for the external database
+    user: ""
+
+    # the password for the external database
+    # - [WARNING] to avoid storing the password in plain-text within your values,
+    #   create a Kubernetes secret and use `externalDatabase.passwordSecret`
+    password: ""
+
+  authz:
+    backend: "allowall"
+
+  serviceAccount:
+    # -- Specifies whether a service account should be created.
+    # If `false`, you must create the you must create the service account outside this chart with name: `serviceAccount.name`
+    create: true
+
+trino:
+  enabled: false
+  cloud: "aws"
+  fullnameOverride: "trino"
+  catalogs: ""
+
+  coordinator:
+    resources:
+      requests:
+        cpu: 1000m
+        memory: 2Gi
+      limits:
+        cpu: 2000m
+        memory: 4Gi
+    additionalVolumes:
+      - name: trino-catalog
+        configMap:
+          name: trino-catalog
+    additionalVolumeMounts:
+      - name: trino-catalog
+        mountPath: /etc/trino/catalog
+
+  worker:
+    resources:
+      requests:
+        cpu: 2000m
+        memory: 4Gi
+      limits:
+        cpu: 4000m
+        memory: 8Gi
+    additionalVolumes:
+      - name: trino-catalog
+        configMap:
+          name: trino-catalog
+    additionalVolumeMounts:
+      - name: trino-catalog
+        mountPath: /etc/trino/catalog
+
+  serviceAccount:
+    # -- Specifies whether a service account should be created
+    create: true
+    # -- The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: "trino"


### PR DESCRIPTION
This pull request introduces a new Helm chart for `promptql-shelf`, providing Kubernetes deployment automation for Lakekeeper and Trino, including their configuration, secrets, and bootstrap/migration jobs. The chart is highly configurable, supporting multiple cloud providers (AWS, GCP, Azure) and external database integration. Key highlights include templated resource definitions, cloud-aware configuration, and pre/post-install hooks for smooth initialization.

**Helm Chart Structure and Core Resources:**

- Added a new `Chart.yaml` defining the `promptql-shelf` chart, its dependencies (`lakekeeper` and `trino`), and metadata.
- Created a `.helmignore` file to exclude unnecessary files from the chart package, improving cleanliness and security.
- Introduced a comprehensive `values.yaml` with configuration options for Lakekeeper, Trino, cloud providers, external databases, and resource limits.

**Lakekeeper Initialization and Security:**

- Added a pre-install migration job (`lakekeeper-preinstall-migration.yaml`) to ensure the Lakekeeper Postgres database exists before installation.
- Added a post-install bootstrap job (`lakekeeper-bootstrap.yaml`) that automates Lakekeeper system bootstrapping and warehouse provisioning for AWS, GCP, or Azure, based on configuration.
- Created a secret resource (`lakekeeper-pg-encryption-secret.yaml`) for securely storing the Lakekeeper Postgres encryption key, with support for conditional creation.

**Trino Catalog Integration:**

- Added a ConfigMap (`trino-catalog-configmap.yaml`) that configures Trino catalogs for Iceberg, TPC-DS, and TPC-H, with cloud-specific settings for S3, GCS, or Azure.