### PR TITLE
Add ndc-trino-jdbc Helm chart

### DIFF
--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -274,4 +274,15 @@ jobs:
                 --values tests/ndc-oracle-jdbc-git-sync-values.yaml \
                 --namespace connector-ns
               ;;
+            ndc-trino-jdbc)
+              echo "Rendering ndc-trino-jdbc"
+              helm template connector charts/ndc-trino-jdbc \
+                --values tests/ndc-trino-jdbc-values.yaml \
+                --namespace connector-ns
+
+              echo "Rendering ndc-trino-jdbc-git-sync"
+              helm template connector-git-sync charts/ndc-trino-jdbc \
+                --values tests/ndc-trino-jdbc-git-sync-values.yaml \
+                --namespace connector-ns
+              ;;
           esac

--- a/CONNECTORS
+++ b/CONNECTORS
@@ -17,3 +17,4 @@ ndc-postgres-jdbc
 ndc-snowflake
 ndc-snowflake-jdbc
 ndc-sqlserver-jdbc
+ndc-trino-jdbc

--- a/charts/ndc-trino-jdbc/.helmignore
+++ b/charts/ndc-trino-jdbc/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+values.override.yaml

--- a/charts/ndc-trino-jdbc/Chart.yaml
+++ b/charts/ndc-trino-jdbc/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: ndc-trino-jdbc
+description: (DDN) A Helm chart for deploying ndc-trino-jdbc
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: v2025.11.20
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "3.0.0"
+
+dependencies:
+- name: common
+  version: 0.0.16
+  repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ndc-trino-jdbc/Chart.yaml
+++ b/charts/ndc-trino-jdbc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.11.20
+version: v2026.04.09
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-trino-jdbc/README.md
+++ b/charts/ndc-trino-jdbc/README.md
@@ -1,0 +1,197 @@
+# Ndc-trino-jdbc Helm Chart
+
+This chart deploys the ndc-trino-jdbc connector (For use under PromptQL use cases). Refer to the pre-requisites section [here](../../README.md#get-started)
+
+## Connector Image
+
+If you're running `docker compose build` within your Supergraph to build a custom connector image, or if you're using
+the **git-sync** option with a Hasura-provided connector image, the base image used in both cases is: `ghcr.io/hasura/ndc-trino-jdbc`
+
+To determine the specific version of the image being used, check the `connector-metadata.yaml` file located under your Supergraph at: `app/connector/<connector-name>/.hasura-connector/connector-metadata.yaml`
+
+## Install Chart
+
+See all [configuration](#parameters) below.
+
+```bash
+# EXAMPLES:
+
+# helm template and apply manifests via kubectl (example)
+helm template <release-name> \
+  --set namespace="default" \
+  --set image.repository="my_repo/ndc-trino-jdbc" \
+  --set image.tag="my_custom_image_tag" \
+  --set connectorEnvVars.JDBC_URL="jdbc_url" \
+  --set connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET="token" \
+  hasura-ddn/ndc-trino-jdbc | kubectl apply -f-
+
+# helm upgrade --install (pass configuration via command line)
+helm upgrade --install <release-name> \
+  --set namespace="default" \
+  --set image.repository="my_repo/ndc-trino-jdbc" \
+  --set image.tag="my_custom_image_tag" \
+  --set connectorEnvVars.JDBC_URL="jdbc_url" \
+  --set connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET="token" \
+  hasura-ddn/ndc-trino-jdbc
+```
+
+## Enabling git-sync
+
+Follow the pre-requisite [here](../../README.md#using-git-for-metadata-files) which has to be done once and deployed on the cluster.
+
+Replace `<git_domain>`, `<org>` and `<repo>` placeholders in the below command to suit your git repository.
+
+Additionally, ensure that `connectorEnvVars.configDirectory` is set to the correct path using the format shown below. Replace `<repo>` with the name of your Git repository, and `<connector-name>` with the name of your connector (found under `app/connector` in your Supergraph repo).  Ensure that you are not adding the `.git` suffix to `<repo>`.
+
+Example: If your repo is `my-repo` and your connector is `my-connector`, the path should be:  `/work-dir/my-repo/app/connector/my-connector`
+
+- Note: For `https` based checkout, a typical URL format for `initContainers.gitSync.repo` will be `https://<git_domain>/<org>/<repo>`.  For `ssh` based checkout, a typical URL format will be `git@<git_domain>:<org>/<repo>`
+
+```bash
+helm upgrade --install <release-name> \
+  --set namespace="default" \
+  --set image.repository="my_repo/ndc-trino-jdbc" \
+  --set image.tag="my_custom_image_tag" \
+  --set connectorEnvVars.JDBC_URL="jdbc_url" \
+  --set connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET="token" \
+  --set initContainers.gitSync.enabled="true" \
+  --set initContainers.gitSync.repo="git@<git_domain>:<org>/<repo>" \
+  --set initContainers.gitSync.branch="main" \
+  --set connectorEnvVars.configDirectory="/work-dir/<repo>/app/connector/<connector-name>" \
+  hasura-ddn/ndc-trino-jdbc
+```
+
+## Committing code to git
+
+When you enable git-sync, the code will be fetched from the repository specified in `initContainers.gitSync.repo`, using the branch defined in `initContainers.gitSync.branch`.
+
+## Private Registry Access via Image Pull Secrets (GCR Auth Example)
+
+To pull container images from a private registry, such as when deploying connectors hosted in a restricted environment, you can configure an image pull secret using either a YAML override or Helm CLI flags.
+
+- Note: The following example demonstrates authentication using a Google Container Registry (GCR) service account with _json_key authentication.
+
+```yaml
+global:
+  # Set to true to deploy the image pull secret defined in the `secrets` section
+  dataPlane:
+    deployImagePullSecret: true
+
+  # Reference the name of the image pull secret to be used
+  # This name must remain consistent and match the one defined in the manifest
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Enable creation of a service account and attach the image pull secret to it
+  serviceAccount:
+    enabled: true
+
+secrets:
+  imagePullSecret:
+    auths:
+      gcr.io:
+        username: "_json_key"
+        # Below content should be replaced with "company-sa.json" file content which is shared by the Hasura team, ensuring that it's indented correctly.
+        password: |
+          {}
+        email: "support@hasura.io"
+```
+
+You can achieve the same configuration from the command line using the following steps:
+
+- Save the service account key (JSON) into a file, e.g., `company-sa.json`
+- Run Helm by adding the following flags:
+
+```yaml
+--set global.dataPlane.deployImagePullSecret=true \
+--set global.imagePullSecrets[0]=hasura-image-pull \
+--set global.serviceAccount.enabled=true \
+--set secrets.imagePullSecret.auths.gcr\.io.username="_json_key" \
+--set secrets.imagePullSecret.auths.gcr\.io.email="support@hasura.io" \
+--set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
+```
+
+## Container Level Security Context
+
+By default, no container-level `securityContext` values are set.
+
+To enable them, you can specify the settings you need. For example, the following Helm values configure `readOnlyRootFilesystem: true`, `runAsNonRoot: true`, `allowPrivilegeEscalation: false`, and `drop all` Linux capabilities:
+
+```yaml
+--set containerSecurityContext.readOnlyRootFilesystem=true \
+--set containerSecurityContext.runAsNonRoot=true \
+--set containerSecurityContext.allowPrivilegeEscalation=false \
+--set containerSecurityContext.capabilities.drop[0]=ALL
+```
+
+You may add any additional fields that are valid container-level Kubernetes `securityContext` options.
+
+**Important Note**
+
+During installation, if you set any value under `containerSecurityContext`, the resulting rendered manifest will include all of the default security settings—merged with the values you explicitly provide.
+
+For example, let's assume that we are only overriding `readOnlyRootFilesystem` to `false`.  The final manifest will look like this:
+
+```yaml
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: false # Only this value was overridden. All other securityContext fields are still included with their default values.
+          runAsNonRoot: true
+```
+
+These defaults appear even if you did not explicitly configure every field, because the chart merges its defaults with your overrides.
+
+## Connector ENV Inputs
+
+| Name                                              | Description                                                                                                | Value                           |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET`    | Hasura Service Token Secret.  This value comes from your Supergraph's `.env` file and corresponds to the connector's `HASURA_SERVICE_TOKEN_SECRET` environment variable. (Optional)                                                                     | `""`                            |
+| `connectorEnvVars.JDBC_URL`                 | The JDBC URL to connect to the Trino database (Required)                                                                         | `""`                            |
+| `connectorEnvVars.JDBC_SCHEMAS`                   | A comma-separated list of schemas to include in the metadata (Optional)                                                                         | `""`                                 |
+| `connectorEnvVars.HASURA_LOG_LEVEL`               | Log level for the connector (Optional)                                                                     | `""`                                 |
+| `connectorEnvVars.configDirectory`                | Connector config directory (See [Enabling git-sync](README.md#enabling-git-sync) when initContainers.gitSync.enabled is set to true) (Optional) | `""`                   |
+| `connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT`    | OTEL Exporter OTLP Endpoint (Optional)                                                                     | `"http://dp-otel-collector:4317"`                   |
+| `connectorEnvVars.OTEL_SERVICE_NAME`              | OTEL Service Name (Optional)                                                                               | `ndc-trino-jdbc`                  |
+
+## Additional Parameters
+
+| Name                                              | Description                                                                                                | Value                           |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `namespace`                                       | Namespace to deploy to                                                                                     | `"default"`                     |
+| `additionalAnnotations.checksum/config`           | Adds a checksum annotation for the `secret.yaml` file to force rollout on changes                          | `{{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}`                     |
+| `additionalAnnotations.app.kubernetes.io/access-group` | Labels resources with an access group for organizational or access control purposes                   | `connector`                     |
+| `networkPolicy.ingress.enabled`                   | Enables ingress network policy rules                                                                       | `true`                          |
+| `networkPolicy.ingress.allowedApps`               | Specifies which applications (by label) are allowed ingress access                                         | `v3-engine`                     |
+| `global.networkPolicy.enabled`                    | Enables or disables rendering of networkPolicy                                                             | `false`                         |
+| `global.dataPlane.deployImagePullSecret`          | Whether to deploy the image pull secret defined in the `secrets` section                                   | `false`                         |
+| `global.imagePullSecrets`                         | A list of image pull secret names to use. These must match what is defined in the `secrets` section        | `hasura-image-pull`             |
+| `global.serviceAccount.enabled`                   | Enable creation of a Kubernetes service account and attach the image pull secret to it                     | `false`                         |
+| `secrets.imagePullSecret.auths.gcr\.io.username`  | Username for authenticating to the container registry                                                      | `_json_key`                     |
+| `secrets.imagePullSecret.auths.gcr\.io.password`  | Points to `company-sa.json` file (via `set-file`)                                                          | `company-sa.json`               |
+| `secrets.imagePullSecret.auths.gcr\.io.email`     | Email associated with the registry authentication                                                          | `support@hasura.io`             |
+| `image.repository`                                | Image repository containing custom created ndc-trino-jdbc                                                    | `""`                            |
+| `image.tag`                                       | Image tag to use for custom created ndc-trino-jdbc                                                           | `""`                            |
+| `image.pullPolicy`                                | Image pull policy                                                                                          | `Always`                        |
+| `resources`                                       | Resource requests and limits of ndc-trino-jdbc container                                                     | `{}`                            |
+| `env`                                             | Env variable section for ndc-trino-jdbc                                                                      | `[]`                            |
+| `replicas`                                        | Replicas setting for pod                                                                                   | `1`                             |
+| `wsInactiveExpiryMins`                            | To be documented                                                                                           | `1`                             |
+| `securityContext`                                 | Define privilege and access control settings for a Pod or Container                                        | `{}`                            |
+| `containerSecurityContext`                        | Define privilege and access control settings for a Container                                               | ``                            |
+| `healthChecks.enabled`                            | Enable health check for ndc-trino-jdbc container                                                             | `false`                         |
+| `healthChecks.livenessProbePath`                  | Health check liveness Probe path ndc-trino-jdbc container                                                    | `"/healthz"`                    |
+| `healthChecks.readinessProbePath`                 | Health check readiness Probe path ndc-trino-jdbc container                                                   | `"/healthz"`                    |
+| `hpa.enabled`                                     | Enable HPA for ndc-trino-jdbc.  Ensure metrics cluster is configured when enabling                           | `false`                         |
+| `hpa.minReplicas`                                 | minReplicas setting for HPA                                                                                | `2`                             |
+| `hpa.maxReplicas`                                 | maxReplicas setting for HPA                                                                                | `4`                             |
+| `hpa.metrics.resource.name`                       | Resource name to autoscale on                                                                              | ``                              |
+| `hpa.metrics.resource.target.averageUtilization`  | Utilization target on specific resource type                                                               | ``                              |
+| `initContainers.gitSync.enabled`                  | Enable reading connector config files from a git repository                                                | `false`                             |
+| `initContainers.gitSync.repo`                     | Git repository to read from (Used when initContainers.gitSync.enabled is set to true)                      | `git@github.com:<org>/<repo>`       |
+| `initContainers.gitSync.branch`                   | Branch to read from (Used when initContainers.gitSync.enabled is set to true)                              | `main`                              |
+| `initContainers.gitSync.secretName`               | Secret name for private key & known hosts (Used when initContainers.gitSync.enabled is set to true)        | `git-creds`                         |
+| `serviceAccount.enabled`                          | Enable user of a service account for pod                                                                   | `false`                         |
+| `serviceAccount.name`                             | Name for the service account                                                                               | `""`                            |

--- a/charts/ndc-trino-jdbc/templates/NOTES.txt
+++ b/charts/ndc-trino-jdbc/templates/NOTES.txt
@@ -1,0 +1,22 @@
+Ndc-trino-jdbc Helm Chart Deployment
+
+1. Deployment Information:
+   - Release Name: {{ .Release.Name }}
+   - Namespace: {{ template "common.namespace" . }}
+   - Chart Name: {{ .Chart.Name }}
+   - Chart Version: {{ .Chart.Version }}
+
+2. Service Information:
+   - Service Name: {{ template "common.name" . }}
+   - Service Port: {{ .Values.httpPort }}
+
+3. Useful Commands:
+   - Check the Deployment Status:
+     helm status {{ .Release.Name }}
+
+   - Get Detailed Information about the Deployment:
+     helm get all {{ .Release.Name }}
+
+4. Clean Up:
+   - To uninstall/delete the deployment, run:
+     helm uninstall {{ .Release.Name }}

--- a/charts/ndc-trino-jdbc/templates/deployment.yaml
+++ b/charts/ndc-trino-jdbc/templates/deployment.yaml
@@ -1,0 +1,2 @@
+# deployment.yaml
+{{- template "common.deployment" . -}}

--- a/charts/ndc-trino-jdbc/templates/hpa.yaml
+++ b/charts/ndc-trino-jdbc/templates/hpa.yaml
@@ -1,0 +1,2 @@
+# hpa.yaml
+{{- template "common.hpa" . -}}

--- a/charts/ndc-trino-jdbc/templates/imagepullsecret.yaml
+++ b/charts/ndc-trino-jdbc/templates/imagepullsecret.yaml
@@ -1,0 +1,16 @@
+{{- if ((.Values.global).dataPlane).deployImagePullSecret -}}
+{{- with .Values.secrets }}
+{{- if .imagePullSecret -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hasura-image-pull
+  namespace: {{ template "common.namespace" $ }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: |
+{{- toJson .imagePullSecret | b64enc | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/ndc-trino-jdbc/templates/networkPolicy.yaml
+++ b/charts/ndc-trino-jdbc/templates/networkPolicy.yaml
@@ -1,0 +1,2 @@
+# networkPolicy.yaml
+{{- template "common.networkPolicy" . -}}

--- a/charts/ndc-trino-jdbc/templates/secret.yaml
+++ b/charts/ndc-trino-jdbc/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-secret" (include "common.name" .) }}
+  namespace: {{ template "common.namespace" $ }}
+data:
+  {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
+  HASURA_SERVICE_TOKEN_SECRET: {{ required "Error: .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET is required!" .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET | b64enc | quote }}
+  {{- end }}
+  JDBC_URL: {{ required "Error: .Values.connectorEnvVars.JDBC_URL is required!" .Values.connectorEnvVars.JDBC_URL | b64enc | quote }}

--- a/charts/ndc-trino-jdbc/templates/service.yaml
+++ b/charts/ndc-trino-jdbc/templates/service.yaml
@@ -1,0 +1,2 @@
+# service.yaml
+{{- template "common.service" . -}}

--- a/charts/ndc-trino-jdbc/templates/serviceaccount.yaml
+++ b/charts/ndc-trino-jdbc/templates/serviceaccount.yaml
@@ -1,0 +1,2 @@
+# serviceaccount.yaml
+{{- template "common.serviceaccount" . -}}

--- a/charts/ndc-trino-jdbc/values.yaml
+++ b/charts/ndc-trino-jdbc/values.yaml
@@ -71,7 +71,7 @@ connectorEnvVars:
   HASURA_SERVICE_TOKEN_SECRET: ""
   JDBC_URL: ""
   JDBC_SCHEMAS: ""
-  HASURA_LOG_LEVEL: ""
+  HASURA_LOG_LEVEL: "info"
   configDirectory: ""
   OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
   OTEL_SERVICE_NAME: ""
@@ -93,10 +93,6 @@ env: |
   - name: JDBC_SCHEMAS
     value: {{ .Values.connectorEnvVars.JDBC_SCHEMAS | quote }}
   {{- end }}
-  {{- if .Values.connectorEnvVars.HASURA_LOG_LEVEL }}
-  - name: HASURA_LOG_LEVEL
-    value: {{ .Values.connectorEnvVars.HASURA_LOG_LEVEL | quote }}
-  {{- end }}
   - name: OTEL_EXPORTER_OTLP_ENDPOINT
     value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
   {{- if .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
@@ -109,4 +105,8 @@ env: |
   {{- if .Values.connectorEnvVars.configDirectory }}
   - name: HASURA_CONFIGURATION_DIRECTORY
     value: {{ .Values.connectorEnvVars.configDirectory }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.HASURA_LOG_LEVEL }}
+  - name: HASURA_LOG_LEVEL
+    value: {{ .Values.connectorEnvVars.HASURA_LOG_LEVEL }}
   {{- end }}

--- a/charts/ndc-trino-jdbc/values.yaml
+++ b/charts/ndc-trino-jdbc/values.yaml
@@ -1,0 +1,112 @@
+useReleaseName: true
+
+additionalAnnotations: |
+  checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+  app.kubernetes.io/access-group: connector
+
+networkPolicy:
+  ingress:
+    enabled: true
+    allowedApps:
+      - v3-engine
+
+# Container Configs
+image:
+  repository: ""
+  tag: ""
+  pullPolicy: IfNotPresent
+replicas: "1"
+wsInactiveExpiryMins: "1"
+securityContext:
+  runAsNonRoot: true
+  runAsGroup: 1000
+  runAsUser: 1000
+  fsGroup: 1000
+
+containerSecurityContext:
+#  runAsNonRoot: true
+#  allowPrivilegeEscalation: false
+#  capabilities:
+#    drop:
+#    - ALL
+#  readOnlyRootFilesystem: true
+
+serviceAccount:
+  enabled: false
+  name: ""
+
+initContainers:
+  gitSync:
+    enabled: false
+    repo: "git@github.com:<org>/<repo>"
+    branch: "main"
+    secretName: ""
+
+healthChecks:
+  enabled: false
+  livenessProbePath: "/healthz"
+  readinessProbePath: "/healthz"
+
+hpa:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 4
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50  # Target 50% CPU utilization per pod
+
+resources: |
+  requests:
+    cpu: "500m"
+    memory: "500Mi"
+  limits:
+    cpu: "1"
+    memory: "1Gi"
+
+connectorEnvVars:
+  HASURA_SERVICE_TOKEN_SECRET: ""
+  JDBC_URL: ""
+  JDBC_SCHEMAS: ""
+  HASURA_LOG_LEVEL: ""
+  configDirectory: ""
+  OTEL_EXPORTER_OTLP_ENDPOINT: "http://dp-otel-collector:4317"
+  OTEL_SERVICE_NAME: ""
+
+env: |
+  {{- if .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET }}
+  - name: HASURA_SERVICE_TOKEN_SECRET
+    valueFrom:
+      secretKeyRef:
+        key: HASURA_SERVICE_TOKEN_SECRET
+        name: {{ printf "%s-secret" (include "common.name" .) }}
+  {{- end }}
+  - name: JDBC_URL
+    valueFrom:
+      secretKeyRef:
+        key: JDBC_URL
+        name: {{ printf "%s-secret" (include "common.name" .) }}
+  {{- if .Values.connectorEnvVars.JDBC_SCHEMAS }}
+  - name: JDBC_SCHEMAS
+    value: {{ .Values.connectorEnvVars.JDBC_SCHEMAS | quote }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.HASURA_LOG_LEVEL }}
+  - name: HASURA_LOG_LEVEL
+    value: {{ .Values.connectorEnvVars.HASURA_LOG_LEVEL | quote }}
+  {{- end }}
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.configDirectory }}
+  - name: HASURA_CONFIGURATION_DIRECTORY
+    value: {{ .Values.connectorEnvVars.configDirectory }}
+  {{- end }}

--- a/tests/ndc-trino-jdbc-git-sync-values.yaml
+++ b/tests/ndc-trino-jdbc-git-sync-values.yaml
@@ -1,0 +1,13 @@
+image:
+  repository: "my_repo/ndc-trino-jdbc"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"
+
+initContainers:
+  gitSync:
+    enabled: true
+    repo: "git@<git_domain>:<org>/<repo>"
+    branch: "main"

--- a/tests/ndc-trino-jdbc-values.yaml
+++ b/tests/ndc-trino-jdbc-values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: "my_repo/ndc-trino-jdbc"
+  tag: "v1.0.0"
+
+connectorEnvVars:
+  JDBC_URL: "jdbc_url"
+  HASURA_SERVICE_TOKEN_SECRET: "token"


### PR DESCRIPTION
## Summary
- New Helm chart for the `ndc-trino-jdbc` connector, modeled after `ndc-postgres-jdbc`
- Supports connector environment variables: `JDBC_URL` (required), `JDBC_SCHEMAS` (optional), `HASURA_LOG_LEVEL` (optional)
- Includes all standard chart features: network policy, HPA, git-sync, image pull secrets, service account, container security context

## Test plan
- [ ] Verify `helm template` renders correctly with required `JDBC_URL` set
- [ ] Verify `helm template` fails with a clear error when `JDBC_URL` is not set
- [ ] Verify optional `JDBC_SCHEMAS` and `HASURA_LOG_LEVEL` are only included when set
- [ ] Verify chart structure matches existing JDBC connector charts (ndc-postgres-jdbc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)