### PR TITLE
feat(ndc-snowflake-jdbc, ndc-sqlserver-jdbc): add external secrets support

### DIFF
--- a/charts/ndc-snowflake-jdbc/Chart.yaml
+++ b/charts/ndc-snowflake-jdbc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2026.05.26
+version: v2026.05.22
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-snowflake-jdbc/Chart.yaml
+++ b/charts/ndc-snowflake-jdbc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.11.20
+version: v2026.05.26
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-snowflake-jdbc/README.md
+++ b/charts/ndc-snowflake-jdbc/README.md
@@ -181,7 +181,7 @@ global:
 # Use the env-loader variant of the connector image
 image:
   repository: "gcr.io/hasura-ee/ndc-snowflake-jdbc"
-  tag: "v3.0.0-env-loader"
+  tag: "v1.7.3-env-loader"
 
 # ServiceAccount must match the Vault role's bound_service_account_names
 serviceAccount:

--- a/charts/ndc-snowflake-jdbc/README.md
+++ b/charts/ndc-snowflake-jdbc/README.md
@@ -111,6 +111,126 @@ You can achieve the same configuration from the command line using the following
 --set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
 ```
 
+## External Secrets (HashiCorp Vault)
+
+When using an external secrets provider such as HashiCorp Vault, the connector can load sensitive environment variables from JSON files written by the `secrets-management-proxy` init container, instead of from Kubernetes Secrets.
+
+### Prerequisites
+
+1. **HashiCorp Vault** must be running and accessible from the cluster.
+2. **Vault Kubernetes auth** must be enabled and configured to trust the cluster's service account issuer.
+3. A **Vault KV v2 secret** must exist at the configured path containing the required keys.
+4. A **Vault role** must be created that binds the connector's Kubernetes ServiceAccount.
+5. The connector image must be the **`-env-loader` variant** (e.g., `ndc-snowflake-jdbc:v3.0.0-env-loader`).
+
+### Required Vault Secret Keys
+
+Create a secret in Vault at your configured path (e.g., `secret/snowflake-secrets`) with the following keys:
+
+| Key | Description | Required |
+| --- | ----------- | -------- |
+| `JDBC_URL` | Snowflake JDBC connection string | Yes |
+| `HASURA_SERVICE_TOKEN_SECRET` | Hasura service token secret (from your Supergraph `.env` file) | Optional |
+
+Example using the Vault CLI:
+
+```bash
+vault kv put secret/snowflake-secrets \
+  JDBC_URL="jdbc:snowflake://acme-org.snowflakecomputing.com/?db=MYDB&schema=PUBLIC&warehouse=COMPUTE_WH&role=ANALYST" \
+  HASURA_SERVICE_TOKEN_SECRET="my-service-token-secret"
+```
+
+### Vault Role Setup
+
+Create a Vault role that authorizes the connector's ServiceAccount:
+
+```bash
+vault write auth/kubernetes/role/hasura-secrets \
+  bound_service_account_names=ndc-snowflake-jdbc \
+  bound_service_account_namespaces=<your-namespace> \
+  policies=hasura-secrets \
+  ttl=1h
+```
+
+### Example Override File
+
+```yaml
+global:
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Disable Kubernetes Secret creation — secrets come from Vault
+  deploySecrets: false
+
+  externalSecrets:
+    enabled: true
+    secretName: "snowflake-secrets"
+    cloud: hashicorp
+    transform:
+      mode: "transformed_only"
+    hashicorp:
+      vaultAddr: "http://vault.vault.svc.cluster.local:8200"
+      mount: "secret"
+      path: "snowflake-secrets"
+      auth:
+        method: kubernetes
+        role: "hasura-secrets"
+        mountPath: "kubernetes"
+        jwtPath: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+# Use the env-loader variant of the connector image
+image:
+  repository: "gcr.io/hasura-ee/ndc-snowflake-jdbc"
+  tag: "v3.0.0-env-loader"
+
+# ServiceAccount must match the Vault role's bound_service_account_names
+serviceAccount:
+  enabled: true
+  name: "ndc-snowflake-jdbc"
+
+externalSecrets:
+  enabled: true
+  type: initcontainer  # use "sidecar" for automatic secret refresh
+  secretRefresher:
+    image:
+      repository: "gcr.io/hasura-ee/secrets-management-proxy"
+      tag: "<secrets-management-proxy-tag>"
+
+# Override the default env block to remove secretKeyRef entries.
+# JDBC_URL and HASURA_SERVICE_TOKEN_SECRET are injected
+# by the env-loader entrypoint from /secrets/*.json at startup.
+env: |
+  {{- if .Values.connectorEnvVars.JDBC_SCHEMAS }}
+  - name: JDBC_SCHEMAS
+    value: {{ .Values.connectorEnvVars.JDBC_SCHEMAS | quote }}
+  {{- end }}
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.configDirectory }}
+  - name: HASURA_CONFIGURATION_DIRECTORY
+    value: {{ .Values.connectorEnvVars.configDirectory }}
+  {{- end }}
+```
+
+### How It Works
+
+1. The `secrets-management-proxy` init container authenticates to Vault using the pod's ServiceAccount token and fetches the secret.
+2. The secret is written as a JSON file to `/secrets/snowflake-secrets.json` on a shared `emptyDir` volume.
+3. The main container uses the `-env-loader` image variant, whose entrypoint script reads every JSON file in `/secrets/`, exports each key/value pair as an environment variable, then execs the connector.
+4. The connector starts with `JDBC_URL` (and any other keys) available as environment variables.
+
+### Init Container vs Sidecar
+
+- **`type: initcontainer`** — secrets are fetched once at startup. If the Vault secret is rotated, a pod restart is required to pick up the new values.
+- **`type: sidecar`** — the secret refresher runs alongside the connector and periodically re-fetches secrets (default: every 5 minutes). The connector's env-loader entrypoint only reads secrets at startup, so a pod restart is still needed for the connector to pick up refreshed values. The sidecar mode is useful when combined with other consumers of the `/secrets/` volume.
+
 ## Container Level Security Context
 
 By default, no container-level `securityContext` values are set.

--- a/charts/ndc-snowflake-jdbc/templates/external-secrets-config.yaml
+++ b/charts/ndc-snowflake-jdbc/templates/external-secrets-config.yaml
@@ -1,0 +1,2 @@
+# external-secrets-config.yaml
+{{- template "common.externalsSecretsConfig" . -}}

--- a/charts/ndc-snowflake-jdbc/templates/secret.yaml
+++ b/charts/ndc-snowflake-jdbc/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.deploySecrets }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,3 +9,4 @@ data:
   HASURA_SERVICE_TOKEN_SECRET: {{ required "Error: .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET is required!" .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET | b64enc | quote }}
   {{- end }}
   JDBC_URL: {{ required "Error: .Values.connectorEnvVars.JDBC_URL is required!" .Values.connectorEnvVars.JDBC_URL | b64enc | quote }}
+{{- end }}

--- a/charts/ndc-snowflake-jdbc/values.yaml
+++ b/charts/ndc-snowflake-jdbc/values.yaml
@@ -58,6 +58,19 @@ containerSecurityContext:
 #    - ALL
 #  readOnlyRootFilesystem: true
 
+# Writable /tmp for the env-loader entrypoint (mktemp requires it).
+extraVolumes: |
+  {{- if and .Values.global.externalSecrets.enabled .Values.externalSecrets.enabled }}
+  - name: tmp
+    emptyDir: {}
+  {{- end }}
+
+extraVolumeMounts: |
+  {{- if and .Values.global.externalSecrets.enabled .Values.externalSecrets.enabled }}
+  - name: tmp
+    mountPath: /tmp
+  {{- end }}
+
 serviceAccount:
   enabled: false
   name: ""

--- a/charts/ndc-snowflake-jdbc/values.yaml
+++ b/charts/ndc-snowflake-jdbc/values.yaml
@@ -1,7 +1,21 @@
 useReleaseName: true
 
+# Global values shared across charts. Overridden by parent/umbrella charts.
+global:
+  # Toggle to read secrets from an external secret store (Azure Key Vault / AWS
+  # Secrets Manager) via the secret-refresher init container. When true, the
+  # main container image tag is suffixed with `-env-loader` so the entrypoint
+  # loads env vars from `/secrets/*.json` written by secret-refresher-init.
+  externalSecrets:
+    enabled: false
+  # When false, the chart skips rendering Kubernetes Secret resources — secret
+  # values are expected to come from the external secret store instead.
+  deploySecrets: true
+
 additionalAnnotations: |
+  {{- if .Values.global.deploySecrets }}
   checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+  {{- end }}
   app.kubernetes.io/access-group: connector
 
 networkPolicy:
@@ -10,11 +24,24 @@ networkPolicy:
     allowedApps:
       - v3-engine
 
+# When externalSecrets is enabled the secret-refresher pattern in the `common`
+# library is used: an init container fetches secrets from the configured cloud
+# vault and writes them as JSON to a shared emptyDir at /secrets, which the
+# main container's `-env-loader` entrypoint reads at startup.
+externalSecrets:
+  enabled: false
+
 # Container Configs
 image:
   repository: ""
   tag: ""
   pullPolicy: IfNotPresent
+  # Appended to the image tag when external secrets are enabled so the chart
+  # selects the env-loader variant of the image. Evaluated by `common.image`.
+  tagSuffix: |
+    {{- if and .Values.global.externalSecrets.enabled .Values.externalSecrets.enabled -}}
+    {{- print "-env-loader" -}}
+    {{- end -}}
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:

--- a/charts/ndc-sqlserver-jdbc/Chart.yaml
+++ b/charts/ndc-sqlserver-jdbc/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: ndc-snowflake-jdbc
-description: (DDN) A Helm chart for deploying ndc-snowflake-jdbc
+name: ndc-sqlserver-jdbc
+description: (DDN) A Helm chart for deploying ndc-sqlserver-jdbc
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/ndc-sqlserver-jdbc/Chart.yaml
+++ b/charts/ndc-sqlserver-jdbc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2026.05.26
+version: v2026.05.22
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-sqlserver-jdbc/Chart.yaml
+++ b/charts/ndc-sqlserver-jdbc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v2025.11.20
+version: v2026.05.26
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ndc-sqlserver-jdbc/README.md
+++ b/charts/ndc-sqlserver-jdbc/README.md
@@ -181,7 +181,7 @@ global:
 # Use the env-loader variant of the connector image
 image:
   repository: "gcr.io/hasura-ee/ndc-sqlserver-jdbc"
-  tag: "v3.0.0-env-loader"
+  tag: "v1.5.3-env-loader"
 
 # ServiceAccount must match the Vault role's bound_service_account_names
 serviceAccount:

--- a/charts/ndc-sqlserver-jdbc/README.md
+++ b/charts/ndc-sqlserver-jdbc/README.md
@@ -111,6 +111,126 @@ You can achieve the same configuration from the command line using the following
 --set-file secrets.imagePullSecret.auths.gcr\.io.password=company-sa.json
 ```
 
+## External Secrets (HashiCorp Vault)
+
+When using an external secrets provider such as HashiCorp Vault, the connector can load sensitive environment variables from JSON files written by the `secrets-management-proxy` init container, instead of from Kubernetes Secrets.
+
+### Prerequisites
+
+1. **HashiCorp Vault** must be running and accessible from the cluster.
+2. **Vault Kubernetes auth** must be enabled and configured to trust the cluster's service account issuer.
+3. A **Vault KV v2 secret** must exist at the configured path containing the required keys.
+4. A **Vault role** must be created that binds the connector's Kubernetes ServiceAccount.
+5. The connector image must be the **`-env-loader` variant** (e.g., `ndc-sqlserver-jdbc:v3.0.0-env-loader`).
+
+### Required Vault Secret Keys
+
+Create a secret in Vault at your configured path (e.g., `secret/sqlserver-secrets`) with the following keys:
+
+| Key | Description | Required |
+| --- | ----------- | -------- |
+| `JDBC_URL` | SQL Server JDBC connection string | Yes |
+| `HASURA_SERVICE_TOKEN_SECRET` | Hasura service token secret (from your Supergraph `.env` file) | Optional |
+
+Example using the Vault CLI:
+
+```bash
+vault kv put secret/sqlserver-secrets \
+  JDBC_URL="jdbc:sqlserver://sqlserver.example.com:1433;databaseName=mydb;encrypt=true;trustServerCertificate=false" \
+  HASURA_SERVICE_TOKEN_SECRET="my-service-token-secret"
+```
+
+### Vault Role Setup
+
+Create a Vault role that authorizes the connector's ServiceAccount:
+
+```bash
+vault write auth/kubernetes/role/hasura-secrets \
+  bound_service_account_names=ndc-sqlserver-jdbc \
+  bound_service_account_namespaces=<your-namespace> \
+  policies=hasura-secrets \
+  ttl=1h
+```
+
+### Example Override File
+
+```yaml
+global:
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Disable Kubernetes Secret creation — secrets come from Vault
+  deploySecrets: false
+
+  externalSecrets:
+    enabled: true
+    secretName: "sqlserver-secrets"
+    cloud: hashicorp
+    transform:
+      mode: "transformed_only"
+    hashicorp:
+      vaultAddr: "http://vault.vault.svc.cluster.local:8200"
+      mount: "secret"
+      path: "sqlserver-secrets"
+      auth:
+        method: kubernetes
+        role: "hasura-secrets"
+        mountPath: "kubernetes"
+        jwtPath: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+# Use the env-loader variant of the connector image
+image:
+  repository: "gcr.io/hasura-ee/ndc-sqlserver-jdbc"
+  tag: "v3.0.0-env-loader"
+
+# ServiceAccount must match the Vault role's bound_service_account_names
+serviceAccount:
+  enabled: true
+  name: "ndc-sqlserver-jdbc"
+
+externalSecrets:
+  enabled: true
+  type: initcontainer  # use "sidecar" for automatic secret refresh
+  secretRefresher:
+    image:
+      repository: "gcr.io/hasura-ee/secrets-management-proxy"
+      tag: "<secrets-management-proxy-tag>"
+
+# Override the default env block to remove secretKeyRef entries.
+# JDBC_URL and HASURA_SERVICE_TOKEN_SECRET are injected
+# by the env-loader entrypoint from /secrets/*.json at startup.
+env: |
+  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+    value: {{ .Values.connectorEnvVars.OTEL_EXPORTER_OTLP_ENDPOINT }}
+  {{- if .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Values.connectorEnvVars.OTEL_SERVICE_NAME }}
+  {{- else }}
+  - name: OTEL_SERVICE_NAME
+    value: {{ .Chart.Name }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.configDirectory }}
+  - name: HASURA_CONFIGURATION_DIRECTORY
+    value: {{ .Values.connectorEnvVars.configDirectory }}
+  {{- end }}
+  {{- if .Values.connectorEnvVars.HASURA_LOG_LEVEL }}
+  - name: HASURA_LOG_LEVEL
+    value: {{ .Values.connectorEnvVars.HASURA_LOG_LEVEL }}
+  {{- end }}
+```
+
+### How It Works
+
+1. The `secrets-management-proxy` init container authenticates to Vault using the pod's ServiceAccount token and fetches the secret.
+2. The secret is written as a JSON file to `/secrets/sqlserver-secrets.json` on a shared `emptyDir` volume.
+3. The main container uses the `-env-loader` image variant, whose entrypoint script reads every JSON file in `/secrets/`, exports each key/value pair as an environment variable, then execs the connector.
+4. The connector starts with `JDBC_URL` (and any other keys) available as environment variables.
+
+### Init Container vs Sidecar
+
+- **`type: initcontainer`** — secrets are fetched once at startup. If the Vault secret is rotated, a pod restart is required to pick up the new values.
+- **`type: sidecar`** — the secret refresher runs alongside the connector and periodically re-fetches secrets (default: every 5 minutes). The connector's env-loader entrypoint only reads secrets at startup, so a pod restart is still needed for the connector to pick up refreshed values. The sidecar mode is useful when combined with other consumers of the `/secrets/` volume.
+
 ## Container Level Security Context
 
 By default, no container-level `securityContext` values are set.

--- a/charts/ndc-sqlserver-jdbc/templates/external-secrets-config.yaml
+++ b/charts/ndc-sqlserver-jdbc/templates/external-secrets-config.yaml
@@ -1,0 +1,2 @@
+# external-secrets-config.yaml
+{{- template "common.externalsSecretsConfig" . -}}

--- a/charts/ndc-sqlserver-jdbc/templates/secret.yaml
+++ b/charts/ndc-sqlserver-jdbc/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.deploySecrets }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,3 +9,4 @@ data:
   HASURA_SERVICE_TOKEN_SECRET: {{ required "Error: .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET is required!" .Values.connectorEnvVars.HASURA_SERVICE_TOKEN_SECRET | b64enc | quote }}
   {{- end }}
   JDBC_URL: {{ required "Error: .Values.connectorEnvVars.JDBC_URL is required!" .Values.connectorEnvVars.JDBC_URL | b64enc | quote }}
+{{- end }}

--- a/charts/ndc-sqlserver-jdbc/values.yaml
+++ b/charts/ndc-sqlserver-jdbc/values.yaml
@@ -58,6 +58,19 @@ containerSecurityContext:
 #    - ALL
 #  readOnlyRootFilesystem: true
 
+# Writable /tmp for the env-loader entrypoint (mktemp requires it).
+extraVolumes: |
+  {{- if and .Values.global.externalSecrets.enabled .Values.externalSecrets.enabled }}
+  - name: tmp
+    emptyDir: {}
+  {{- end }}
+
+extraVolumeMounts: |
+  {{- if and .Values.global.externalSecrets.enabled .Values.externalSecrets.enabled }}
+  - name: tmp
+    mountPath: /tmp
+  {{- end }}
+
 serviceAccount:
   enabled: false
   name: ""

--- a/charts/ndc-sqlserver-jdbc/values.yaml
+++ b/charts/ndc-sqlserver-jdbc/values.yaml
@@ -1,7 +1,21 @@
 useReleaseName: true
 
+# Global values shared across charts. Overridden by parent/umbrella charts.
+global:
+  # Toggle to read secrets from an external secret store (Azure Key Vault / AWS
+  # Secrets Manager) via the secret-refresher init container. When true, the
+  # main container image tag is suffixed with `-env-loader` so the entrypoint
+  # loads env vars from `/secrets/*.json` written by secret-refresher-init.
+  externalSecrets:
+    enabled: false
+  # When false, the chart skips rendering Kubernetes Secret resources — secret
+  # values are expected to come from the external secret store instead.
+  deploySecrets: true
+
 additionalAnnotations: |
+  {{- if .Values.global.deploySecrets }}
   checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+  {{- end }}
   app.kubernetes.io/access-group: connector
 
 networkPolicy:
@@ -10,11 +24,24 @@ networkPolicy:
     allowedApps:
       - v3-engine
 
+# When externalSecrets is enabled the secret-refresher pattern in the `common`
+# library is used: an init container fetches secrets from the configured cloud
+# vault and writes them as JSON to a shared emptyDir at /secrets, which the
+# main container's `-env-loader` entrypoint reads at startup.
+externalSecrets:
+  enabled: false
+
 # Container Configs
 image:
   repository: ""
   tag: ""
   pullPolicy: IfNotPresent
+  # Appended to the image tag when external secrets are enabled so the chart
+  # selects the env-loader variant of the image. Evaluated by `common.image`.
+  tagSuffix: |
+    {{- if and .Values.global.externalSecrets.enabled .Values.externalSecrets.enabled -}}
+    {{- print "-env-loader" -}}
+    {{- end -}}
 replicas: "1"
 wsInactiveExpiryMins: "1"
 securityContext:


### PR DESCRIPTION
## Summary

Wires the `ndc-snowflake-jdbc` and `ndc-sqlserver-jdbc` charts through the `common` library's secret-refresher pattern so self-hosted deployments can source secrets from an external vault (Azure Key Vault / AWS Secrets Manager) instead of from a Kubernetes `Secret`.

Mirrors the changes made in #58 for `ndc-mongodb`. Almost all of the heavy lifting (init-container injection, volume wiring, configmap defaults) is provided by the `common` library — this PR only adds the values and the one-liner ConfigMap template that every other Hasura service uses (`templates/external-secrets-config.yaml` → `common.externalsSecretsConfig`).

For **Morgan Stanley's Azure Key Vault integration** for the self-hosted PromptQL deployment.

Refs:
- Reference PR (ndc-mongodb): https://github.com/hasura/ddn-helm-charts/pull/58
- Originating thread: https://prompt.ql.app/project/hasuraql/promptql-playground/thread/39694721-3536-4a14-8257-7adef4054ce2
- ndc-jdbc PR that builds the `-env-loader` images: _coming separately_

## Changes

For both `charts/ndc-snowflake-jdbc/` and `charts/ndc-sqlserver-jdbc/`:

- `Chart.yaml`
  - Bumps `common` dependency from `0.0.16` → `0.0.18`.
  - (`ndc-sqlserver-jdbc/Chart.yaml` is also restored — it was inadvertently removed in commit e8065b0.)
- `values.yaml`
  - New `global.externalSecrets.enabled: false` and `global.deploySecrets: true` block.
  - New `externalSecrets.enabled: false` chart-level toggle (both must be true to activate; matches the convention in `solutions/helm/services/`).
  - New `image.tagSuffix` that resolves to `-env-loader` when external secrets are enabled, consumed by `common.image`.
  - `additionalAnnotations.checksum/config` now only emits when `global.deploySecrets` is true so the annotation doesn't reference an unrendered file.
- `templates/secret.yaml` — gated on `.Values.global.deploySecrets`.
- `templates/external-secrets-config.yaml` (new) — one-liner delegating to `common.externalsSecretsConfig`.

No changes to `templates/deployment.yaml` — `common.deployment` already handles `secret-refresher-init` injection, the `/secrets` mount, and the `-env-loader` tag suffix once the values above are wired.

## Behavior

**Default (`externalSecrets.enabled=false`)** — no change: plain image, `Secret` rendered as before, external-secrets ConfigMap is empty (template no-ops).

**Enabled (`global.externalSecrets.enabled=true`, `global.externalSecrets.cloud=azure`, `externalSecrets.enabled=true`, `global.deploySecrets=false`)** — image becomes `<registry>/<chart>:<tag>-env-loader`, `secret-refresher-init` runs with `runAsUser: 1001` and writes Azure Key Vault contents to a shared emptyDir at `/secrets`, main container reads `/secrets/*.json` via the env-loader entrypoint, `Secret` resource is not rendered.

## Test plan

- [x] `helm lint charts/ndc-snowflake-jdbc` — clean (pre-existing version-format warning is unrelated).
- [x] `helm lint charts/ndc-sqlserver-jdbc` — clean (pre-existing version-format warning is unrelated).
- [x] `helm template` with defaults — matches pre-change render except for an empty `external-secrets-config.yaml` document.
- [x] `helm template` with external secrets enabled — init container, volumes, env-loader tag suffix, and Azure-flavored refresh ConfigMap all present; Secret is gone.
- [ ] End-to-end deploy in Morgan Stanley dev environment with Azure Key Vault wired up — requires reviewer.
- [ ] Confirm the `<registry>/ndc-snowflake-jdbc:<tag>-env-loader` and `<registry>/ndc-sqlserver-jdbc:<tag>-env-loader` images are published by the release pipeline (tracked by the upcoming ndc-jdbc PR).

Co-authored-by: Tomasz Skawinski <tom@hasura.io>

🤖 Generated with [Claude Code](https://claude.com/claude-code)