### PR TITLE
feat(ddn-workspace): Add external secrets support for HashiCorp Vault

### DIFF
--- a/charts/ddn-workspace/Chart.yaml
+++ b/charts/ddn-workspace/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: ddn-workspace
 description: A Helm chart for DDN Workspace (Native Runtime)
 type: application
-version: v2025.11.13
+version: v2026.05.28
 appVersion: "3.0.0"
 dependencies:
 - name: common
-  version: 0.0.16
+  version: 0.0.19
   repository: oci://us-west1-docker.pkg.dev/hasura-ee/helm-charts

--- a/charts/ddn-workspace/README.md
+++ b/charts/ddn-workspace/README.md
@@ -257,6 +257,124 @@ Both methods will immediately invalidate the session cookie and return:
 - Auth-proxy admin port (9901) is never exposed externally for security
 - **Logout endpoint** (`/logout`) immediately invalidates sessions for enhanced security
 
+## External Secrets (HashiCorp Vault)
+
+When using an external secrets provider such as HashiCorp Vault, the workspace can load the `WORKSPACE_PASSWORD` environment variable from JSON files written by the `secrets-management-proxy` init container, instead of from a Kubernetes Secret. This is an alternative to setting `secrets.password` directly when `workspaceAuthProxy` is disabled.
+
+### Prerequisites
+
+1. **HashiCorp Vault** must be running and accessible from the cluster.
+2. **Vault Kubernetes auth** must be enabled and configured to trust the cluster's service account issuer.
+3. A **Vault KV v2 secret** must exist at the configured path containing the required keys.
+4. A **Vault role** must be created that binds the workspace's Kubernetes ServiceAccount.
+5. The workspace image must be the **`-env-loader` variant** (e.g., `ddn-native-workspace:<tag>-env-loader`). When `global.externalSecrets.enabled` and `externalSecrets.enabled` are both true, the chart appends `-env-loader` to the configured `image.tag` automatically.
+
+### Required Vault Secret Keys
+
+Create a secret in Vault at your configured path (e.g., `secret/workspace-secrets`) with the following key:
+
+| Key | Description | Required |
+| --- | ----------- | -------- |
+| `WORKSPACE_PASSWORD` | Argon2id-hashed workspace password (same value you would pass to `secrets.password`) | Yes |
+
+Example using the Vault CLI:
+
+```bash
+vault kv put secret/workspace-secrets \
+  WORKSPACE_PASSWORD='$argon2id$v=19$m=16,t=2,p=1$TGY1cnNQblpGNmlCSnV4VQ$1/DpAKkaZhEtHDyVBqpF9A'
+```
+
+### Vault Role Setup
+
+Create a Vault role that authorizes the workspace's ServiceAccount:
+
+```bash
+vault write auth/kubernetes/role/hasura-secrets \
+  bound_service_account_names=ddn-workspace \
+  bound_service_account_namespaces=<your-namespace> \
+  policies=hasura-secrets \
+  ttl=1h
+```
+
+### Example Override File
+
+```yaml
+global:
+  domain: "hasura-dp.domain.com"
+  imagePullSecrets:
+    - hasura-image-pull
+
+  # Disable Kubernetes Secret creation — secrets come from Vault
+  deploySecrets: false
+
+  externalSecrets:
+    enabled: true
+    secretName: "workspace-secrets"
+    cloud: hashicorp
+    transform:
+      mode: "transformed_only"
+    hashicorp:
+      vaultAddr: "http://vault.vault.svc.cluster.local:8200"
+      mount: "secret"
+      path: "workspace-secrets"
+      auth:
+        method: kubernetes
+        role: "hasura-secrets"
+        mountPath: "kubernetes"
+        jwtPath: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+consoleUrl: "https://console.my-cp.domain.com"
+
+# The chart will append `-env-loader` to image.tag automatically when
+# global.externalSecrets.enabled and externalSecrets.enabled are both true.
+image:
+  tag: "2.6.1"
+
+# ServiceAccount must match the Vault role's bound_service_account_names
+serviceAccount:
+  enabled: true
+  name: "ddn-workspace"
+
+externalSecrets:
+  enabled: true
+  type: initcontainer  # use "sidecar" for automatic secret refresh
+  secretRefresher:
+    image:
+      repository: "gcr.io/hasura-ee/secrets-management-proxy"
+      tag: "<secrets-management-proxy-tag>"
+
+# Override the default env block to remove the secretKeyRef entry for
+# WORKSPACE_PASSWORD. HASHED_PASSWORD is injected by the env-loader entrypoint
+# from /secrets/*.json (read as WORKSPACE_PASSWORD) at startup.
+env: |
+  - name: CODE_SERVER_PORT
+    value: "8123"
+  - name: HASHED_PASSWORD
+    value: "$(WORKSPACE_PASSWORD)"
+  - name: HASURA_DDN_INSECURE_SKIP_TLS_VERIFY
+    value: {{ .Values.skipTlsVerify | quote }}
+  {{- if .Values.setControlPlaneUrls }}
+  - name: HASURA_DDN_CONSOLE_HOST
+    value: {{ required "DDN Console URL (.Values.consoleUrl) is required" .Values.consoleUrl | quote }}
+  - name: HASURA_DDN_CONTROL_PLANE_HOST
+    value: {{ required "Data URL is required" .Values.dataHost | quote }}
+  - name: HASURA_DDN_CONNECTOR_HUB_REGISTRY_HOST
+    value: {{ required "DDN CPS Engine URL is required" .Values.ddnCpsEngineHost | quote }}
+  {{- end }}
+```
+
+### How It Works
+
+1. The `secrets-management-proxy` init container authenticates to Vault using the pod's ServiceAccount token and fetches the secret.
+2. The secret is written as a JSON file to `/secrets/workspace-secrets.json` on a shared `emptyDir` volume.
+3. The main container uses the `-env-loader` image variant, whose entrypoint script reads every JSON file in `/secrets/`, exports each key/value pair as an environment variable, then execs the workspace.
+4. The workspace starts with `WORKSPACE_PASSWORD` available as an environment variable, which is wired through to `HASHED_PASSWORD` by the chart's `env` block.
+
+### Init Container vs Sidecar
+
+- **`type: initcontainer`** — secrets are fetched once at startup. If the Vault secret is rotated, a pod restart is required to pick up the new values.
+- **`type: sidecar`** — the secret refresher runs alongside the workspace and periodically re-fetches secrets (default: every 5 minutes). The workspace's env-loader entrypoint only reads secrets at startup, so a pod restart is still needed for the workspace to pick up refreshed values. The sidecar mode is useful when combined with other consumers of the `/secrets/` volume.
+
 ## Trusting CA certs
 
 If you are using an SSL Certificate under your Control Plane ingresses which is tied to a CA (Certificate Authority) that is only trusted by your company, you

--- a/charts/ddn-workspace/README.md
+++ b/charts/ddn-workspace/README.md
@@ -259,7 +259,7 @@ Both methods will immediately invalidate the session cookie and return:
 
 ## External Secrets (HashiCorp Vault)
 
-When using an external secrets provider such as HashiCorp Vault, the workspace can load the `WORKSPACE_PASSWORD` environment variable from JSON files written by the `secrets-management-proxy` init container, instead of from a Kubernetes Secret. This is an alternative to setting `secrets.password` directly when `workspaceAuthProxy` is disabled.
+When using an external secrets provider such as HashiCorp Vault, the workspace can load the `HASHED_PASSWORD` environment variable from JSON files written by the `secrets-management-proxy` init container, instead of from a Kubernetes Secret. This is an alternative to setting `secrets.password` directly when `workspaceAuthProxy` is disabled.
 
 ### Prerequisites
 
@@ -275,13 +275,13 @@ Create a secret in Vault at your configured path (e.g., `secret/workspace-secret
 
 | Key | Description | Required |
 | --- | ----------- | -------- |
-| `WORKSPACE_PASSWORD` | Argon2id-hashed workspace password (same value you would pass to `secrets.password`) | Yes |
+| `HASHED_PASSWORD` | Argon2id-hashed workspace password. The workspace's entrypoint expects this exact key name. | Yes |
 
 Example using the Vault CLI:
 
 ```bash
 vault kv put secret/workspace-secrets \
-  WORKSPACE_PASSWORD='$argon2id$v=19$m=16,t=2,p=1$TGY1cnNQblpGNmlCSnV4VQ$1/DpAKkaZhEtHDyVBqpF9A'
+  HASHED_PASSWORD='$argon2id$v=19$m=16,t=2,p=1$TGY1cnNQblpGNmlCSnV4VQ$1/DpAKkaZhEtHDyVBqpF9A'
 ```
 
 ### Vault Role Setup
@@ -343,32 +343,16 @@ externalSecrets:
       repository: "gcr.io/hasura-ee/secrets-management-proxy"
       tag: "<secrets-management-proxy-tag>"
 
-# Override the default env block to remove the secretKeyRef entry for
-# WORKSPACE_PASSWORD. HASHED_PASSWORD is injected by the env-loader entrypoint
-# from /secrets/*.json (read as WORKSPACE_PASSWORD) at startup.
-env: |
-  - name: CODE_SERVER_PORT
-    value: "8123"
-  - name: HASHED_PASSWORD
-    value: "$(WORKSPACE_PASSWORD)"
-  - name: HASURA_DDN_INSECURE_SKIP_TLS_VERIFY
-    value: {{ .Values.skipTlsVerify | quote }}
-  {{- if .Values.setControlPlaneUrls }}
-  - name: HASURA_DDN_CONSOLE_HOST
-    value: {{ required "DDN Console URL (.Values.consoleUrl) is required" .Values.consoleUrl | quote }}
-  - name: HASURA_DDN_CONTROL_PLANE_HOST
-    value: {{ required "Data URL is required" .Values.dataHost | quote }}
-  - name: HASURA_DDN_CONNECTOR_HUB_REGISTRY_HOST
-    value: {{ required "DDN CPS Engine URL is required" .Values.ddnCpsEngineHost | quote }}
-  {{- end }}
+# No env override needed: HASHED_PASSWORD is injected automatically by the
+# env-loader entrypoint from /secrets/*.json at startup, matching the key
+# name the workspace already expects.
 ```
 
 ### How It Works
 
 1. The `secrets-management-proxy` init container authenticates to Vault using the pod's ServiceAccount token and fetches the secret.
 2. The secret is written as a JSON file to `/secrets/workspace-secrets.json` on a shared `emptyDir` volume.
-3. The main container uses the `-env-loader` image variant, whose entrypoint script reads every JSON file in `/secrets/`, exports each key/value pair as an environment variable, then execs the workspace.
-4. The workspace starts with `WORKSPACE_PASSWORD` available as an environment variable, which is wired through to `HASHED_PASSWORD` by the chart's `env` block.
+3. The main container uses the `-env-loader` image variant, whose entrypoint script reads every JSON file in `/secrets/`, exports each key/value pair as an environment variable, then execs the workspace. The workspace starts with `HASHED_PASSWORD` available directly — no mapping or custom `env` block is needed because the Vault key name matches what the workspace expects.
 
 ### Init Container vs Sidecar
 

--- a/charts/ddn-workspace/README.md
+++ b/charts/ddn-workspace/README.md
@@ -261,6 +261,8 @@ Both methods will immediately invalidate the session cookie and return:
 
 When using an external secrets provider such as HashiCorp Vault, the workspace can load the `HASHED_PASSWORD` environment variable from JSON files written by the `secrets-management-proxy` init container, instead of from a Kubernetes Secret. This is an alternative to setting `secrets.password` directly when `workspaceAuthProxy` is disabled.
 
+**Note:** External secrets support is available starting with release 2.7.9.
+
 ### Prerequisites
 
 1. **HashiCorp Vault** must be running and accessible from the cluster.
@@ -321,14 +323,21 @@ global:
         method: kubernetes
         role: "hasura-secrets"
         mountPath: "kubernetes"
-        jwtPath: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        # Use an audience-bound projected ServiceAccount token for Vault
+        # Kubernetes auth. When enabled, jwtPath defaults to
+        # /var/run/secrets/projectedtokens/vault-token (set by the common
+        # chart), so it does not need to be configured explicitly.
+        projectedToken:
+          enabled: true
+          audience: "vault"
+          expirationSeconds: 7200
 
 consoleUrl: "https://console.my-cp.domain.com"
 
 # The chart will append `-env-loader` to image.tag automatically when
 # global.externalSecrets.enabled and externalSecrets.enabled are both true.
 image:
-  tag: "2.6.1"
+  tag: "2.7.9"
 
 # ServiceAccount must match the Vault role's bound_service_account_names
 serviceAccount:
@@ -353,6 +362,14 @@ externalSecrets:
 1. The `secrets-management-proxy` init container authenticates to Vault using the pod's ServiceAccount token and fetches the secret.
 2. The secret is written as a JSON file to `/secrets/workspace-secrets.json` on a shared `emptyDir` volume.
 3. The main container uses the `-env-loader` image variant, whose entrypoint script reads every JSON file in `/secrets/`, exports each key/value pair as an environment variable, then execs the workspace. The workspace starts with `HASHED_PASSWORD` available directly — no mapping or custom `env` block is needed because the Vault key name matches what the workspace expects.
+
+### Vault Kubernetes Auth: Projected ServiceAccount Tokens
+
+By default, the secret-refresher authenticates to Vault using the pod's default ServiceAccount token (mounted at `/var/run/secrets/kubernetes.io/serviceaccount/token`). Setting `global.externalSecrets.hashicorp.auth.projectedToken.enabled: true` switches to an audience-bound, short-lived projected ServiceAccount token instead, which is the recommended posture for Vault Kubernetes auth. When enabled:
+
+1. A `projected` volume named `vault-projected-token` is added to the pod, with a `serviceAccountToken` source using the configured `audience` (default `"vault"`) and `expirationSeconds` (default `7200`).
+2. The volume is mounted on the secret-refresher container at `/var/run/secrets/projectedtokens`, so the token is available at `/var/run/secrets/projectedtokens/vault-token`.
+3. The secret-refresher's Vault config uses that path as `jwt_path` (the default switches automatically when `projectedToken.enabled` is true), so Vault Kubernetes auth verifies the audience-bound token instead of the default ServiceAccount token.
 
 ### Init Container vs Sidecar
 

--- a/charts/ddn-workspace/templates/external-secrets-config.yaml
+++ b/charts/ddn-workspace/templates/external-secrets-config.yaml
@@ -1,0 +1,2 @@
+# external-secrets-config.yaml
+{{- template "common.externalsSecretsConfig" . -}}

--- a/charts/ddn-workspace/templates/secrets.yaml
+++ b/charts/ddn-workspace/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.deploySecrets }}
 {{- $secretsName := include "common.secretsName" . -}}
 {{- if not (include "ddn-workspace.workspaceAuthProxy.enabled" .) }}
 {{- with .Values.secrets }}
@@ -9,5 +10,6 @@ metadata:
   namespace: {{ template "common.namespace" $ }}
 data:
   WORKSPACE_PASSWORD: {{ required "Error: secrets.password is required when auth-proxy is disabled!" .password | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/ddn-workspace/values.yaml
+++ b/charts/ddn-workspace/values.yaml
@@ -15,6 +15,16 @@ global:
     enabled: true
   routes:
     enabled: false
+  # Toggle to read secrets from an external secret store (Azure Key Vault / AWS
+  # Secrets Manager / HashiCorp Vault) via the secret-refresher init container.
+  # When true, the main container image tag is suffixed with `-env-loader` so
+  # the entrypoint loads env vars from `/secrets/*.json` written by
+  # secret-refresher-init.
+  externalSecrets:
+    enabled: false
+  # When false, the chart skips rendering the Kubernetes Secret resource —
+  # secret values are expected to come from the external secret store instead.
+  deploySecrets: true
 
 additionalLabels:
   group: ddn-workspace
@@ -31,10 +41,23 @@ networkPolicy:
 
 useReleaseName: true
 
+# When externalSecrets is enabled the secret-refresher pattern in the `common`
+# library is used: an init container fetches secrets from the configured cloud
+# vault and writes them as JSON to a shared emptyDir at /secrets, which the
+# main container's `-env-loader` entrypoint reads at startup.
+externalSecrets:
+  enabled: false
+
 # Container Configs
 image:
   repository: "ddn-native-workspace"
   tag: ""
+  # Appended to the image tag when external secrets are enabled so the chart
+  # selects the env-loader variant of the image. Evaluated by `common.image`.
+  tagSuffix: |
+    {{- if and .Values.global.externalSecrets.enabled .Values.externalSecrets.enabled -}}
+    {{- print "-env-loader" -}}
+    {{- end -}}
 replicas: "1"
 httpPort: 8123
 setControlPlaneUrls: true

--- a/charts/ddn-workspace/values.yaml
+++ b/charts/ddn-workspace/values.yaml
@@ -111,11 +111,13 @@ env: |
   - name: CODE_SERVER_PORT
     value: "8123"
   {{- if not (include "ddn-workspace.workspaceAuthProxy.enabled" .) }}
+  {{- if .Values.global.deploySecrets }}
   - name: HASHED_PASSWORD
     valueFrom:
       secretKeyRef:
         name: {{ include "common.secretsName" $ }}
         key: WORKSPACE_PASSWORD
+  {{- end }}
   {{- else }}
   - name: CODE_SERVER_NO_AUTH
     value: "true"


### PR DESCRIPTION
## Summary

- Wires the `ddn-workspace` chart into the same secret-refresher pattern already used by `ndc-mongodb`, `ndc-snowflake-jdbc`, and `ndc-sqlserver-jdbc`, so `WORKSPACE_PASSWORD` can be sourced from an external secret store (e.g. HashiCorp Vault) instead of a Kubernetes Secret.
- Bumps chart version to `v2026.05.28` and the `common` dependency to `0.0.19`.
- Adds `global.externalSecrets` / `global.deploySecrets` toggles, a local `externalSecrets` block, and an `image.tagSuffix` template that appends `-env-loader` when both toggles are enabled.
- Guards `templates/secrets.yaml` with `global.deploySecrets` (in addition to the existing auth-proxy check) and adds `templates/external-secrets-config.yaml` which renders the `common.externalsSecretsConfig` helper.
- Documents the Vault flow, prerequisites, required secret key (`WORKSPACE_PASSWORD`), and example overrides in the chart README.

This follows the same pattern landed in #58 / #59 for `ndc-mongodb` / `ndc-snowflake-jdbc` / `ndc-sqlserver-jdbc` — no behavior change unless `global.externalSecrets.enabled` and `externalSecrets.enabled` are both set to `true`.

Originating thread: https://prompt.ql.app/project/hasuraql/promptql-playground/thread/3c7e0165-6c4d-4e19-9a28-22405407c5dd

## Test plan

- [ ] `helm template` with defaults renders identical output to the current chart (no `external-secrets-config` resource, `Secret` rendered as before).
- [ ] `helm template` with `global.externalSecrets.enabled=true`, `externalSecrets.enabled=true`, `global.deploySecrets=false` skips the `Secret`, renders the external-secrets config, and the deployment image is suffixed with `-env-loader`.
- [ ] `helm template` with `workspaceAuthProxy.enabled=true` continues to skip the `Secret` as before.
- [ ] `helm lint charts/ddn-workspace` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)